### PR TITLE
Update help text

### DIFF
--- a/stdump.cpp
+++ b/stdump.cpp
@@ -219,7 +219,7 @@ static Options parse_args(int argc, char** argv) {
 			options.mode = OUTPUT_PER_FILE;
 			continue;
 		}
-		if(arg == "--test" || arg == "-t") {
+		if(arg == "--test") {
 			only_one();
 			options.mode = OUTPUT_TEST;
 			continue;
@@ -249,7 +249,7 @@ static Options parse_args(int argc, char** argv) {
 void print_help() {
 	puts("stdump: MIPS/GCC symbol table parser.");
 	puts("");
-	puts("OPTIONS:");
+	puts("MODES:");
 	puts(" --symbols, -s      Print a list of all the local symbols, grouped");
 	puts("                    by file descriptor.");
 	puts("");
@@ -258,7 +258,7 @@ void print_help() {
 	puts(" --types, -t        Print a deduplicated list of all the types defined");
 	puts("                    in the MIPS debug section as C data structures.");
 	puts("");
-	puts(" --per-file, -t     Print a list of all the types defined in the MIPS");
+	puts(" --per-file, -p     Print a list of all the types defined in the MIPS");
 	puts("                    debug section, where for each file descriptor");
 	puts("                    all types used are duplicated.");
 	puts("");
@@ -266,6 +266,7 @@ void print_help() {
 	puts("                    assertions to test if the offset and size of each");
 	puts("                    field is correct for a given platform/compiler.");
 	puts("");
+	puts("OPTIONS:");
 	puts(" --language <lang>  Set the output language. <lang> can be set to");
 	puts("                    either cpp or json.");
 	puts("");


### PR DESCRIPTION
Hi, I know this is a small change, but I figured I might as well, since it'd be some git practice for me.

Changes to the help message:
- Change `-t` to `-p` for `--per-file`, as that's what the program actually checks for.
- Break up the help text into `MODES:` and `OPTIONS:`, helping the user realize modes are mutually exclusive, or at the very least give more context for which flags count as modes if running into "error: Multiple mode flags specified".

Changes to the argument parsing:
- Remove `-t` for `--test` (it was unreachable due to `--types` having the same short option, and the help text did not even mention it anyway). Also shows that `--test` is seldom used/different from the other modes.