### PR TITLE
Remove ccc_int128 hack

### DIFF
--- a/ccc/ast.cpp
+++ b/ccc/ast.cpp
@@ -54,12 +54,7 @@ static TypeName resolve_c_type_name(const std::map<s32, const StabsType*>& types
 			case StabsTypeDescriptor::STRUCT: name.first_part += "struct "; break;
 			case StabsTypeDescriptor::UNION: name.first_part += "union "; break;
 		}
-		// FIXME: Actually check the bounds of long long int.
-		if(type.type_number == 6 && type.name == "long long int") {
-			name.first_part = "struct ccc_int128";
-		} else {
-			name.first_part += *type.name;
-		}
+		name.first_part += *type.name;
 		return name;
 	}
 	

--- a/ccc/print.cpp
+++ b/ccc/print.cpp
@@ -55,10 +55,6 @@ void print_ast(FILE* output, const std::vector<AstNode>& ast_nodes, OutputLangua
 
 void print_c_ast_begin(FILE* output) {
 	printf("\n");
-	fprintf(output, "struct ccc_int128 {\n");
-	fprintf(output, "\tlong int lo;\n");
-	fprintf(output, "\tlong int hi;\n");
-	fprintf(output, "};\n");
 }
 
 void print_c_forward_declarations(FILE* output, const std::vector<AstNode>& ast_nodes) {


### PR DESCRIPTION
ee-gcc compiles both ``long int`` and ``long long int`` as 64-bit integers. Notice that both types have the same upper and lower bounds in the stabs info.
```
long int:t3=r1;001000000000000000000000;000777777777777777777777;
long long int:t6=r1;001000000000000000000000;000777777777777777777777;
```
Moreover, ccc doesn't treat type 7 (``long long unsigned int``) the same way as its signed counterpart.

For what it's worth, ee-gcc can create 128-bit integers via the GNU-C extension ``__attribute__((mode(TI)))`` and the built-in types ``__int128``, ``__int128_t``, and ``__uint128_t``.