### PR TITLE
Simplify how the ordering of elements in a source file is handled

### DIFF
--- a/ImportStdumpSymbolsIntoGhidra.java
+++ b/ImportStdumpSymbolsIntoGhidra.java
@@ -286,7 +286,6 @@ public class ImportStdumpSymbolsIntoGhidra extends GhidraScript {
 			int absolute_offset_bytes = -1;
 			int bitfield_offset_bits = -1;
 			int size_bits = -1;
-			int order = -1;
 			int first_file = -1;
 			boolean conflict = false;
 			int stabs_type_number = -1;
@@ -645,7 +644,7 @@ public class ImportStdumpSymbolsIntoGhidra extends GhidraScript {
 				throws JsonParseException {
 			ParsedJsonFile result = new ParsedJsonFile();
 			JsonObject object = element.getAsJsonObject();
-			int supported_version = 5;
+			int supported_version = 6;
 			if(!object.has("version")) {
 				throw new JsonParseException("JSON file has missing version number field.");
 			}
@@ -870,9 +869,6 @@ public class ImportStdumpSymbolsIntoGhidra extends GhidraScript {
 			}
 			if(src.has("size_bits")) {
 				dest.size_bits = src.get("size_bits").getAsInt();
-			}
-			if(src.has("order")) {
-				dest.order = src.get("order").getAsInt();
 			}
 			if(src.has("files")) {
 				dest.first_file = src.get("files").getAsJsonArray().get(0).getAsInt();

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Half-working EE core MIPS disassembler. Probably not too interesting.
 
 | Version | Changes |
 | - | - |
+| 6 | Removed 'order' property. |
 | 5 | Added 'pointer_to_data_member' node type. Added optional is_volatile property to all nodes. Added is_by_reference property to variable storage objects. |
 | 4 | Added optional is_const property to all nodes. Added 'anonymous_reference' type names, where the type name is not valid but the type number is. |
 | 3 | Added optional relative_path property to function definition nodes. |

--- a/ccc/ast.cpp
+++ b/ccc/ast.cpp
@@ -408,7 +408,7 @@ void remove_duplicate_self_typedefs(std::vector<std::unique_ptr<Node>>& ast_node
 }
 
 void TypeDeduplicatorOMatic::process_file(ast::SourceFile& file, s32 file_index) {
-	for(std::unique_ptr<Node>& node : file.types) {
+	for(std::unique_ptr<Node>& node : file.data_types) {
 		auto existing_node_iterator = name_to_deduplicated_index.find(node->name);
 		if(existing_node_iterator == name_to_deduplicated_index.end()) {
 			// No types with this name have previously been processed.
@@ -456,7 +456,7 @@ void TypeDeduplicatorOMatic::process_file(ast::SourceFile& file, s32 file_index)
 			}
 		}
 	}
-	file.types.clear();
+	file.data_types.clear();
 }
 
 std::vector<std::unique_ptr<Node>> TypeDeduplicatorOMatic::finish() {

--- a/ccc/print_cpp.cpp
+++ b/ccc/print_cpp.cpp
@@ -317,9 +317,15 @@ void print_cpp_ast_node(FILE* dest, const ast::Node& node, VariableName& parent_
 		}
 		case ast::SOURCE_FILE: {
 			const ast::SourceFile& source_file = node.as<ast::SourceFile>();
-			source_file.in_order([&](const ast::Node& child) {
-				print_cpp_ast_node(dest, child, name, indentation_level, digits_for_offset);
-			});
+			for(const std::unique_ptr<ast::Node>& type : source_file.data_types) {
+				print_cpp_ast_node(dest, *type.get(), name, indentation_level, digits_for_offset);
+			}
+			for(const std::unique_ptr<ast::Node>& function : source_file.functions) {
+				print_cpp_ast_node(dest, *function.get(), name, indentation_level, digits_for_offset);
+			}
+			for(const std::unique_ptr<ast::Node>& global : source_file.globals) {
+				print_cpp_ast_node(dest, *global.get(), name, indentation_level, digits_for_offset);
+			}
 			break;
 		}
 		case ast::TYPE_NAME: {

--- a/ccc/print_json.cpp
+++ b/ccc/print_json.cpp
@@ -32,7 +32,7 @@ void print_json(FILE* dest, const AnalysisResults& src, bool print_per_file_type
 	
 	json.begin_object();
 	
-	json.number_property("version", 5);
+	json.number_property("version", 6);
 	
 	json.property("files");
 	json.begin_array();
@@ -78,9 +78,6 @@ static void print_json_ast_node(JsonWriter& json, const ast::Node* ptr) {
 	}
 	if(node.is_volatile) {
 		json.boolean_property("is_volatile", node.is_volatile);
-	}
-	if(node.order != -1) {
-		json.number_property("order", node.order);
 	}
 	if(node.conflict) {
 		json.boolean_property("conflict", true);
@@ -250,7 +247,7 @@ static void print_json_ast_node(JsonWriter& json, const ast::Node* ptr) {
 			json.number_property("text_address", source_file.text_address);
 			json.property("types");
 			json.begin_array();
-			for(const std::unique_ptr<ast::Node>& type : source_file.types) {
+			for(const std::unique_ptr<ast::Node>& type : source_file.data_types) {
 				print_json_ast_node(json, type.get());
 			}
 			json.end_array();

--- a/stdump.cpp
+++ b/stdump.cpp
@@ -178,9 +178,9 @@ static void print_types_per_file(mdebug::SymbolTable& symbol_table, const Option
 		printf("// *****************************************************************************\n");
 		printf("\n");
 		print_cpp_comment_block_compiler_version_info(stdout, symbol_table);
-		print_cpp_comment_block_builtin_types(stdout, source_file.types);
+		print_cpp_comment_block_builtin_types(stdout, source_file.data_types);
 		printf("\n");
-		print_cpp_ast_nodes(stdout, source_file.types, options.flags & FLAG_VERBOSE);
+		print_cpp_ast_nodes(stdout, source_file.data_types, options.flags & FLAG_VERBOSE);
 		printf("\n");
 	}
 }


### PR DESCRIPTION
The debug symbols don't preserve the ordering of functions relative to globals so the old ordering mechanism isn't really necessary.