### PR TITLE
Rewrite the version finder cmake script

### DIFF
--- a/cmake/git_tag.cpp
+++ b/cmake/git_tag.cpp
@@ -1,0 +1,3 @@
+const char* git_tag() {
+	return GIT_TAG;
+}

--- a/cmake/version_finder.cmake
+++ b/cmake/version_finder.cmake
@@ -1,30 +1,17 @@
-# Fetch the git tag and generate a .h/.cpp file pair that defines the git_tag
-# function to make it available at runtime.
-set(GIT_TAG_CPP_PATH "${CMAKE_BINARY_DIR}/git_tag.cpp")
-set(GIT_TAG_CPP [[
-const char* git_tag() {
-	return ""
-		#include "git_tag.h"
-	;
-}
-]])
-set(GIT_TAG_H_PATH "${CMAKE_BINARY_DIR}/git_tag.h")
-set(GIT_TAG_FORMAT [[\"%\(refname:strip=2\)\"]])
-file(WRITE "${GIT_TAG_CPP_PATH}" "${GIT_TAG_CPP}")
-file(WRITE "${GIT_TAG_H_PATH}" "")
 find_package(Git QUIET)
 if(GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
 	message(STATUS "Found git")
-	add_custom_command(
-		COMMAND ${GIT_EXECUTABLE} tag --points-at HEAD --format "${GIT_TAG_FORMAT}" > "${GIT_TAG_H_PATH}"
-		DEPENDS "${CMAKE_SOURCE_DIR}/*"
-		OUTPUT "${GIT_TAG_H_PATH}"
+	execute_process(
+		COMMAND ${GIT_EXECUTABLE} tag --points-at HEAD
+		OUTPUT_VARIABLE GIT_TAG
+		OUTPUT_STRIP_TRAILING_WHITESPACE
 	)
 else()
 	message(WARNING "Cannot find git")
+	set(GIT_TAG "")
 endif()
 
 add_library(versioninfo STATIC
-	"${GIT_TAG_CPP_PATH}"
-	"${GIT_TAG_H_PATH}"
+	${CMAKE_SOURCE_DIR}/cmake/git_tag.cpp
 )
+target_compile_definitions(versioninfo PRIVATE -DGIT_TAG="${GIT_TAG}")

--- a/cmake/zip_crafter.cmake
+++ b/cmake/zip_crafter.cmake
@@ -1,13 +1,5 @@
 # Package up all the files for a release. This is to be run as part of a CI job.
 if(ZIP_RELEASE)
-	if(NOT (${CMAKE_BUILD_TYPE} MATCHES ""))
-		message(FATAL "Zip files can only be produced for release builds.")
-	endif()
-	execute_process(
-		COMMAND ${GIT_EXECUTABLE} tag --points-at HEAD
-		OUTPUT_VARIABLE RELEASE_VERSION
-		OUTPUT_STRIP_TRAILING_WHITESPACE
-	)
 	if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 		set(RELEASE_OS "linux")
 	elseif(APPLE)
@@ -17,7 +9,7 @@ if(ZIP_RELEASE)
 	else()
 		set(RELEASE_OS ${CMAKE_SYSTEM_NAME})
 	endif()
-	set(RELEASE_NAME "ccc_${RELEASE_VERSION}_${RELEASE_OS}")
+	set(RELEASE_NAME "ccc_${GIT_TAG}_${RELEASE_OS}")
 	add_custom_target(releasezip ALL
 		COMMAND
 			${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/${RELEASE_NAME}" &&


### PR DESCRIPTION
This version grabs the git tag only at configure time, but it only really matters for CI builds anyway.