### PR TITLE
Dramatically reduce memory usage, remove stdump's --verbose option

### DIFF
--- a/ccc/analysis.cpp
+++ b/ccc/analysis.cpp
@@ -395,7 +395,7 @@ Result<void> LocalSymbolTableAnalyser::label(const char* label, u32 address, s32
 
 Result<void> LocalSymbolTableAnalyser::text_end(const char* name, s32 function_size) {
 	if(m_state == IN_FUNCTION_BEGINNING) {
-		if(m_current_function->address_range.low >= 0) {
+		if(m_current_function->address_range.low != (u32) -1) {
 			CCC_ASSERT(m_current_function);
 			m_current_function->address_range.high = m_current_function->address_range.low + function_size;
 		}

--- a/ccc/analysis.h
+++ b/ccc/analysis.h
@@ -24,7 +24,7 @@ enum AnalysisFlags {
 
 // Perform all the main analysis passes on the mdebug symbol table and convert
 // it to a set of C++ ASTs.
-Result<HighSymbolTable> analyse(const mdebug::SymbolTable& symbol_table, u32 flags, s32 file_descriptor_index = -1);
+Result<HighSymbolTable> analyse(const mdebug::SymbolTable& symbol_table, u32 flags, s32 file_index = -1);
 
 // Build a map of type names to their index is the deduplicated_types array.
 std::map<std::string, s32> build_type_name_to_deduplicated_type_index_map(const HighSymbolTable& symbol_table);

--- a/ccc/ast.h
+++ b/ccc/ast.h
@@ -218,6 +218,7 @@ struct SourceFile : Node {
 	std::vector<std::unique_ptr<Node>> functions;
 	std::vector<std::unique_ptr<Node>> globals;
 	std::map<StabsTypeNumber, s32> stabs_type_number_to_deduplicated_type_index;
+	std::set<std::string> toolchain_version_info;
 	
 	SourceFile() : Node(DESCRIPTOR) {}
 	static const constexpr NodeDescriptor DESCRIPTOR = SOURCE_FILE;

--- a/ccc/ast.h
+++ b/ccc/ast.h
@@ -77,7 +77,6 @@ struct Node {
 	std::string name;
 	
 	std::vector<s32> files; // List of files for which a given top-level type is present.
-	const ParsedSymbol* symbol = nullptr;
 	const char* compare_fail_reason = "";
 	StabsTypeNumber stabs_type_number;
 	
@@ -218,7 +217,6 @@ struct SourceFile : Node {
 	std::vector<std::unique_ptr<Node>> data_types;
 	std::vector<std::unique_ptr<Node>> functions;
 	std::vector<std::unique_ptr<Node>> globals;
-	std::vector<ParsedSymbol> symbols;
 	std::map<StabsTypeNumber, s32> stabs_type_number_to_deduplicated_type_index;
 	
 	SourceFile() : Node(DESCRIPTOR) {}

--- a/ccc/mdebug.cpp
+++ b/ccc/mdebug.cpp
@@ -90,87 +90,149 @@ CCC_PACKED_STRUCT(ExternalSymbolHeader,
 	/* 0x4 */ SymbolHeader symbol;
 )
 
-static s32 get_corruption_fixing_fudge_offset(u32 section_offset, const SymbolicHeader& hdrr);
+static s32 get_corruption_fixing_fudge_offset(s32 section_offset, const SymbolicHeader& hdrr);
 static Result<Symbol> parse_symbol(const SymbolHeader& header, const std::vector<u8>& elf, s32 strings_offset);
 
-Result<SymbolTable> parse_symbol_table(const std::vector<u8>& elf, u32 section_offset) {
-	SymbolTable symbol_table;
+Result<void> SymbolTable::init(const std::vector<u8>& elf, s32 section_offset) {
+	m_elf = &elf;
+	m_section_offset = section_offset;
 	
-	const SymbolicHeader* hdrr = get_packed<SymbolicHeader>(elf, section_offset);
-	CCC_CHECK(hdrr != nullptr, "MIPS debug section header out of bounds.");
-	CCC_CHECK(hdrr->magic == 0x7009, "Invalid symbolic header.");
+	m_hdrr = get_packed<SymbolicHeader>(*m_elf, m_section_offset);
+	CCC_CHECK(m_hdrr != nullptr, "MIPS debug section header out of bounds.");
+	CCC_CHECK(m_hdrr->magic == 0x7009, "Invalid symbolic header.");
 	
-	symbol_table.header = hdrr;
+	m_fudge_offset = get_corruption_fixing_fudge_offset(m_section_offset, *m_hdrr);
 	
-	s32 fudge_offset = get_corruption_fixing_fudge_offset(section_offset, *hdrr);
+	m_ready = true;
 	
-	// Iterate over file descriptors.
-	for(s64 i = 0; i < hdrr->file_descriptor_count; i++) {
-		u64 fd_offset = hdrr->file_descriptors_offset + i * sizeof(FileDescriptor);
-		const FileDescriptor* fd_header = get_packed<FileDescriptor>(elf, fd_offset + fudge_offset);
-		CCC_CHECK(fd_header != nullptr, "MIPS debug file descriptor out of bounds.");
-		CCC_CHECK(fd_header->f_big_endian == 0, "Not little endian or bad file descriptor table.");
-		
-		SymFileDescriptor& fd = symbol_table.files.emplace_back();
-		fd.header = fd_header;
-		
-		s32 raw_path_offset = hdrr->local_strings_offset + fd_header->strings_offset + fd_header->file_path_string_offset + fudge_offset;
-		Result<const char*> raw_path = get_string(elf, raw_path_offset);
-		CCC_RETURN_IF_ERROR(raw_path);
-		fd.raw_path = *raw_path;
-		
-		// Try to detect the source language.
-		std::string lower_name = fd.raw_path;
-		for(char& c : lower_name) c = tolower(c);
-		if(lower_name.ends_with(".c")) {
-			fd.detected_language = SourceLanguage::C;
-		} else if(lower_name.ends_with(".cpp") || lower_name.ends_with(".cc") || lower_name.ends_with(".cxx")) {
-			fd.detected_language = SourceLanguage::CPP;
-		} else if(lower_name.ends_with(".s") || lower_name.ends_with(".asm")) {
-			fd.detected_language = SourceLanguage::ASSEMBLY;
-		}
-		
-		// Parse local symbols.
-		for(s64 j = 0; j < fd_header->symbol_count; j++) {
-			u64 sym_offset = hdrr->local_symbols_offset + (fd_header->isym_base + j) * sizeof(SymbolHeader);
-			const SymbolHeader* symbol_header = get_packed<SymbolHeader>(elf, sym_offset + fudge_offset);
-			CCC_CHECK(symbol_header != nullptr, "Symbol header out of bounds.");
-			
-			s32 strings_offset = hdrr->local_strings_offset + fd_header->strings_offset + fudge_offset;
-			Result<Symbol> sym = parse_symbol(*symbol_header, elf, strings_offset);
-			CCC_RETURN_IF_ERROR(sym);
-			
-			bool string_offset_equal = (s32) symbol_header->iss == fd_header->file_path_string_offset;
-			if(fd.base_path.empty() && string_offset_equal && sym->is_stabs && sym->code == N_SO && fd.symbols.size() > 2) {
-				const Symbol& base_path = fd.symbols.back();
-				if(base_path.is_stabs && base_path.code == N_SO) {
-					fd.base_path = base_path.string;
-				}
-			}
-			
-			fd.symbols.emplace_back(std::move(*sym));
-		}
-		
-		fd.full_path = merge_paths(fd.base_path, fd.raw_path);
-	}
+	return Result<void>();
+}
 	
-	// Parse external symbols.
-	for(s64 i = 0; i < hdrr->external_symbols_count; i++) {
-		u64 sym_offset = hdrr->external_symbols_offset + i * sizeof(ExternalSymbolHeader);
-		const ExternalSymbolHeader* external_header = get_packed<ExternalSymbolHeader>(elf, sym_offset + fudge_offset);
-		CCC_CHECK(external_header != nullptr, "External header out of bounds.");
-		Result<Symbol> sym = parse_symbol(external_header->symbol, elf, hdrr->external_strings_offset + fudge_offset);
-		CCC_RETURN_IF_ERROR(sym);
-		symbol_table.externals.emplace_back(std::move(*sym));
-	}
-	
-	return symbol_table;
+s32 SymbolTable::file_count() const {
+	CCC_ASSERT(m_ready);
+	return m_hdrr->file_descriptor_count;
 }
 
-static s32 get_corruption_fixing_fudge_offset(u32 section_offset, const SymbolicHeader& hdrr) {
-	// If the .mdebug section was moved without updating its contents all the
-	// absolute file offsets stored within will be incorrect by a fixed amount.
+Result<File> SymbolTable::parse_file(s32 index) const {
+	CCC_ASSERT(m_ready);
 	
+	File file;
+	
+	u64 fd_offset = m_hdrr->file_descriptors_offset + index * sizeof(FileDescriptor);
+	const FileDescriptor* fd_header = get_packed<FileDescriptor>(*m_elf, fd_offset + m_fudge_offset);
+	CCC_CHECK(fd_header != nullptr, "MIPS debug file descriptor out of bounds.");
+	CCC_CHECK(fd_header->f_big_endian == 0, "Not little endian or bad file descriptor table.");
+	
+	s32 raw_path_offset = m_hdrr->local_strings_offset + fd_header->strings_offset + fd_header->file_path_string_offset + m_fudge_offset;
+	Result<const char*> raw_path = get_string(*m_elf, raw_path_offset);
+	CCC_RETURN_IF_ERROR(raw_path);
+	file.raw_path = *raw_path;
+	
+	// Try to detect the source language.
+	std::string lower_name = file.raw_path;
+	for(char& c : lower_name) c = tolower(c);
+	if(lower_name.ends_with(".c")) {
+		file.detected_language = SourceLanguage::C;
+	} else if(lower_name.ends_with(".cpp") || lower_name.ends_with(".cc") || lower_name.ends_with(".cxx")) {
+		file.detected_language = SourceLanguage::CPP;
+	} else if(lower_name.ends_with(".s") || lower_name.ends_with(".asm")) {
+		file.detected_language = SourceLanguage::ASSEMBLY;
+	}
+	
+	// Parse local symbols.
+	for(s64 j = 0; j < fd_header->symbol_count; j++) {
+		u64 symbol_offset = m_hdrr->local_symbols_offset + (fd_header->isym_base + j) * sizeof(SymbolHeader) + m_fudge_offset;
+		const SymbolHeader* symbol_header = get_packed<SymbolHeader>(*m_elf, symbol_offset);
+		CCC_CHECK(symbol_header != nullptr, "Symbol header out of bounds.");
+		
+		s32 strings_offset = m_hdrr->local_strings_offset + fd_header->strings_offset + m_fudge_offset;
+		Result<Symbol> sym = parse_symbol(*symbol_header, *m_elf, strings_offset);
+		CCC_RETURN_IF_ERROR(sym);
+		
+		bool string_offset_equal = (s32) symbol_header->iss == fd_header->file_path_string_offset;
+		if(file.base_path.empty() && string_offset_equal && sym->is_stabs && sym->code == N_SO && file.symbols.size() > 2) {
+			const Symbol& base_path = file.symbols.back();
+			if(base_path.is_stabs && base_path.code == N_SO) {
+				file.base_path = base_path.string;
+			}
+		}
+		
+		file.symbols.emplace_back(std::move(*sym));
+	}
+	
+	file.full_path = merge_paths(file.base_path, file.raw_path);
+	
+	return file;
+}
+
+Result<std::vector<Symbol>> SymbolTable::parse_external_symbols() const {
+	CCC_ASSERT(m_ready);
+	
+	std::vector<Symbol> external_symbols;
+	for(s64 i = 0; i < m_hdrr->external_symbols_count; i++) {
+		u64 sym_offset = m_hdrr->external_symbols_offset + i * sizeof(ExternalSymbolHeader);
+		const ExternalSymbolHeader* external_header = get_packed<ExternalSymbolHeader>(*m_elf, sym_offset + m_fudge_offset);
+		CCC_CHECK(external_header != nullptr, "External header out of bounds.");
+		Result<Symbol> sym = parse_symbol(external_header->symbol, *m_elf, m_hdrr->external_strings_offset + m_fudge_offset);
+		CCC_RETURN_IF_ERROR(sym);
+		external_symbols.emplace_back(std::move(*sym));
+	}
+	return external_symbols;
+}
+
+void SymbolTable::print_header(FILE* dest) const {
+	CCC_ASSERT(m_ready);
+	
+	fprintf(dest, "Symbolic Header, magic = %hx, vstamp = %hx:\n",
+		(u16) m_hdrr->magic,
+		(u16) m_hdrr->version_stamp);
+	fprintf(dest, "\n");
+	fprintf(dest, "                              Offset              Size (Bytes)        Count\n");
+	fprintf(dest, "                              ------              ------------        -----\n");
+	fprintf(dest, "  Line Numbers                0x%-8x          "  "0x%-8x          "  "%-8d\n",
+		(u32) m_hdrr->line_numbers_offset,
+		(u32) m_hdrr->line_numbers_size_bytes,
+		(u32) m_hdrr->line_number_count);
+	fprintf(dest, "  Dense Numbers               0x%-8x          "  "0x%-8x          "  "%-8d\n",
+		(u32) m_hdrr->dense_numbers_offset,
+		(u32) m_hdrr->dense_numbers_count * 8,
+		(u32) m_hdrr->dense_numbers_count);
+	fprintf(dest, "  Procedure Descriptors       0x%-8x          "  "0x%-8x          "  "%-8d\n",
+		(u32) m_hdrr->procedure_descriptors_offset,
+		(u32) m_hdrr->procedure_descriptor_count * (u32) sizeof(ProcedureDescriptor),
+		(u32) m_hdrr->procedure_descriptor_count);
+	fprintf(dest, "  Local Symbols               0x%-8x          "  "0x%-8x          "  "%-8d\n",
+		(u32) m_hdrr->local_symbols_offset,
+		(u32) m_hdrr->local_symbol_count * (u32) sizeof(SymbolHeader),
+		(u32) m_hdrr->local_symbol_count);
+	fprintf(dest, "  Optimization Symbols        0x%-8x          "  "-                   "  "%-8d\n",
+		(u32) m_hdrr->optimization_symbols_offset,
+		(u32) m_hdrr->optimization_symbols_count);
+	fprintf(dest, "  Auxiliary Symbols           0x%-8x          "  "0x%-8x          "  "%-8d\n",
+		(u32) m_hdrr->auxiliary_symbols_offset,
+		(u32) m_hdrr->auxiliary_symbol_count * 4,
+		(u32) m_hdrr->auxiliary_symbol_count);
+	fprintf(dest, "  Local Strings               0x%-8x          "  "-                   "  "%-8d\n",
+		(u32) m_hdrr->local_strings_offset,
+		(u32) m_hdrr->local_strings_size_bytes);
+	fprintf(dest, "  External Strings            0x%-8x          "  "-                   "  "%-8d\n",
+		(u32) m_hdrr->external_strings_offset,
+		(u32) m_hdrr->external_strings_size_bytes);
+	fprintf(dest, "  File Descriptors            0x%-8x          "  "0x%-8x          "  "%-8d\n",
+		(u32) m_hdrr->file_descriptors_offset,
+		(u32) m_hdrr->file_descriptor_count * (u32) sizeof(FileDescriptor),
+		(u32) m_hdrr->file_descriptor_count);
+	fprintf(dest, "  Relative Files Descriptors  0x%-8x          "  "0x%-8x          "  "%-8d\n",
+		(u32) m_hdrr->relative_file_descriptors_offset,
+		(u32) m_hdrr->relative_file_descriptor_count * 4,
+		(u32) m_hdrr->relative_file_descriptor_count);
+	fprintf(dest, "  External Symbols            0x%-8x          "  "0x%-8x          "  "%-8d\n",
+		(u32) m_hdrr->external_symbols_offset,
+		(u32) m_hdrr->external_symbols_count * 16,
+		(u32) m_hdrr->external_symbols_count);
+}
+
+static s32 get_corruption_fixing_fudge_offset(s32 section_offset, const SymbolicHeader& hdrr) {
 	// Test for corruption.
 	s32 right_after_header = INT32_MAX;
 	if(hdrr.line_numbers_offset > 0) right_after_header = std::min(hdrr.line_numbers_offset, right_after_header);
@@ -185,7 +247,7 @@ static s32 get_corruption_fixing_fudge_offset(u32 section_offset, const Symbolic
 	if(hdrr.relative_file_descriptors_offset > 0) right_after_header = std::min(hdrr.relative_file_descriptors_offset, right_after_header);
 	if(hdrr.external_symbols_offset > 0) right_after_header = std::min(hdrr.external_symbols_offset, right_after_header);
 	
-	if(right_after_header == (s32) (section_offset + sizeof(SymbolicHeader))) {
+	if(right_after_header == section_offset + (s32) sizeof(SymbolicHeader)) {
 		return 0; // It's probably fine.
 	}
 	
@@ -221,57 +283,6 @@ static Result<Symbol> parse_symbol(const SymbolHeader& header, const std::vector
 		symbol.is_stabs = false;
 	}
 	return symbol;
-}
-
-void print_headers(FILE* dest, const SymbolTable& symbol_table) {
-	const SymbolicHeader& hdrr = *symbol_table.header;
-	fprintf(dest, "Symbolic Header, magic = %hx, vstamp = %hx:\n",
-		(u16) hdrr.magic,
-		(u16) hdrr.version_stamp);
-	fprintf(dest, "\n");
-	fprintf(dest, "                              Offset              Size (Bytes)        Count\n");
-	fprintf(dest, "                              ------              ------------        -----\n");
-	fprintf(dest, "  Line Numbers                0x%-8x          "  "0x%-8x          "  "%-8d\n",
-		(u32) hdrr.line_numbers_offset,
-		(u32) hdrr.line_numbers_size_bytes,
-		(u32) hdrr.line_number_count);
-	fprintf(dest, "  Dense Numbers               0x%-8x          "  "0x%-8x          "  "%-8d\n",
-		(u32) hdrr.dense_numbers_offset,
-		(u32) hdrr.dense_numbers_count * 8,
-		(u32) hdrr.dense_numbers_count);
-	fprintf(dest, "  Procedure Descriptors       0x%-8x          "  "0x%-8x          "  "%-8d\n",
-		(u32) hdrr.procedure_descriptors_offset,
-		(u32) hdrr.procedure_descriptor_count * (u32) sizeof(ProcedureDescriptor),
-		(u32) hdrr.procedure_descriptor_count);
-	fprintf(dest, "  Local Symbols               0x%-8x          "  "0x%-8x          "  "%-8d\n",
-		(u32) hdrr.local_symbols_offset,
-		(u32) hdrr.local_symbol_count * (u32) sizeof(SymbolHeader),
-		(u32) hdrr.local_symbol_count);
-	fprintf(dest, "  Optimization Symbols        0x%-8x          "  "-                   "  "%-8d\n",
-		(u32) hdrr.optimization_symbols_offset,
-		(u32) hdrr.optimization_symbols_count);
-	fprintf(dest, "  Auxiliary Symbols           0x%-8x          "  "0x%-8x          "  "%-8d\n",
-		(u32) hdrr.auxiliary_symbols_offset,
-		(u32) hdrr.auxiliary_symbol_count * 4,
-		(u32) hdrr.auxiliary_symbol_count);
-	fprintf(dest, "  Local Strings               0x%-8x          "  "-                   "  "%-8d\n",
-		(u32) hdrr.local_strings_offset,
-		(u32) hdrr.local_strings_size_bytes);
-	fprintf(dest, "  External Strings            0x%-8x          "  "-                   "  "%-8d\n",
-		(u32) hdrr.external_strings_offset,
-		(u32) hdrr.external_strings_size_bytes);
-	fprintf(dest, "  File Descriptors            0x%-8x          "  "0x%-8x          "  "%-8d\n",
-		(u32) hdrr.file_descriptors_offset,
-		(u32) hdrr.file_descriptor_count * (u32) sizeof(FileDescriptor),
-		(u32) hdrr.file_descriptor_count);
-	fprintf(dest, "  Relative Files Descriptors  0x%-8x          "  "0x%-8x          "  "%-8d\n",
-		(u32) hdrr.relative_file_descriptors_offset,
-		(u32) hdrr.relative_file_descriptor_count * 4,
-		(u32) hdrr.relative_file_descriptor_count);
-	fprintf(dest, "  External Symbols            0x%-8x          "  "0x%-8x          "  "%-8d\n",
-		(u32) hdrr.external_symbols_offset,
-		(u32) hdrr.external_symbols_count * 16,
-		(u32) hdrr.external_symbols_count);
 }
 
 const char* symbol_type(SymbolType type) {

--- a/ccc/mdebug.cpp
+++ b/ccc/mdebug.cpp
@@ -97,7 +97,7 @@ Result<SymbolTable> parse_symbol_table(const std::vector<u8>& elf, u32 section_o
 	SymbolTable symbol_table;
 	
 	const SymbolicHeader* hdrr = get_packed<SymbolicHeader>(elf, section_offset);
-	CCC_CHECK(hdrr != nullptr, "MIPS_DEBUG section header out of bounds.");
+	CCC_CHECK(hdrr != nullptr, "MIPS debug section header out of bounds.");
 	CCC_CHECK(hdrr->magic == 0x7009, "Invalid symbolic header.");
 	
 	symbol_table.header = hdrr;
@@ -108,7 +108,7 @@ Result<SymbolTable> parse_symbol_table(const std::vector<u8>& elf, u32 section_o
 	for(s64 i = 0; i < hdrr->file_descriptor_count; i++) {
 		u64 fd_offset = hdrr->file_descriptors_offset + i * sizeof(FileDescriptor);
 		const FileDescriptor* fd_header = get_packed<FileDescriptor>(elf, fd_offset + fudge_offset);
-		CCC_CHECK(fd_header != nullptr, "MIPS_DEBUG file descriptor out of bounds.");
+		CCC_CHECK(fd_header != nullptr, "MIPS debug file descriptor out of bounds.");
 		CCC_CHECK(fd_header->f_big_endian == 0, "Not little endian or bad file descriptor table.");
 		
 		SymFileDescriptor& fd = symbol_table.files.emplace_back();

--- a/ccc/print_cpp.cpp
+++ b/ccc/print_cpp.cpp
@@ -147,9 +147,6 @@ bool CppPrinter::data_type(const ast::Node& node) {
 	if(node.descriptor == ast::NodeDescriptor::TYPE_NAME && node.as<ast::TypeName>().source == ast::TypeNameSource::ERROR) {
 		fprintf(out, "// warning: this type name was generated to handle an error\n");
 	}
-	if(verbose && node.symbol != nullptr) {
-		fprintf(out, "// symbol: %s\n", node.symbol->raw->string);
-	}
 	
 	VariableName name;
 	if(node.descriptor == ast::STRUCT_OR_UNION && node.size_bits > 0) {

--- a/ccc/print_cpp.cpp
+++ b/ccc/print_cpp.cpp
@@ -37,17 +37,14 @@ void CppPrinter::comment_block_beginning(const char* input_file) {
 	has_anything_been_printed = true;
 }
 
-void CppPrinter::comment_block_compiler_version_info(const mdebug::SymbolTable& symbol_table) {
+void CppPrinter::comment_block_toolchain_version_info(const HighSymbolTable& symbol_table) {
 	std::set<std::string> compiler_version_info;
-	for(const mdebug::SymFileDescriptor& fd : symbol_table.files) {
-		bool known = false;
-		for(const mdebug::Symbol& symbol : fd.symbols) {
-			if(symbol.storage_class == mdebug::SymbolClass::INFO && strcmp(symbol.string, "@stabs") != 0) {
-				known = true;
-				compiler_version_info.emplace(symbol.string);
+	for(const std::unique_ptr<ast::SourceFile>& source_file : symbol_table.source_files) {
+		if(!source_file->toolchain_version_info.empty()) {
+			for(const std::string& string : source_file->toolchain_version_info) {
+				compiler_version_info.emplace(string);
 			}
-		}
-		if(!known) {
+		} else {
 			compiler_version_info.emplace("unknown");
 		}
 	}

--- a/ccc/print_cpp.h
+++ b/ccc/print_cpp.h
@@ -31,7 +31,7 @@ struct CppPrinter {
 	CppPrinter(FILE* o) : out(o) {}
 	
 	void comment_block_beginning(const char* input_file);
-	void comment_block_compiler_version_info(const mdebug::SymbolTable& symbol_table);
+	void comment_block_toolchain_version_info(const HighSymbolTable& symbol_table);
 	void comment_block_builtin_types(const std::vector<std::unique_ptr<ast::Node>>& ast_nodes);
 	void comment_block_file(const char* path);
 	void begin_include_guard(const char* macro);

--- a/ccc/print_cpp.h
+++ b/ccc/print_cpp.h
@@ -13,7 +13,6 @@ struct VariableName {
 
 struct CppPrinter {
 	FILE* out;
-	bool verbose : 1 = false;
 	bool make_globals_extern : 1 = false;
 	bool skip_statics : 1 = false;
 	bool print_offsets_and_sizes : 1 = true;

--- a/ccc/stabs.cpp
+++ b/ccc/stabs.cpp
@@ -378,7 +378,7 @@ Result<std::unique_ptr<StabsType>> parse_stabs_type(const char*& input) {
 		}
 		default: {
 			return CCC_FAILURE(
-				"Invalid type descriptor '%c' (%02x). Please file a bug report!",
+				"Invalid type descriptor '%c' (%02x).",
 				(u32) descriptor, (u32) descriptor);
 		}
 	}

--- a/ccc/stabs_to_ast.cpp
+++ b/ccc/stabs_to_ast.cpp
@@ -318,7 +318,7 @@ Result<std::unique_ptr<ast::Node>> stabs_type_to_ast(const StabsType& type, cons
 		}
 		case StabsTypeDescriptor::BUILTIN: {
 			CCC_CHECK(type.as<StabsBuiltInType>().type_id == 16,
-				"Unknown built-in type! Please file a bug report.");
+				"Unknown built-in type!");
 			auto builtin = std::make_unique<ast::BuiltIn>();
 			builtin->bclass = BuiltInClass::BOOL_8;
 			result = std::move(builtin);

--- a/ccc/stabs_to_ast.cpp
+++ b/ccc/stabs_to_ast.cpp
@@ -11,7 +11,6 @@ Result<std::unique_ptr<ast::Node>> stabs_data_type_symbol_to_ast(const ParsedSym
 	AST_DEBUG_PRINTF("ANALYSING %s\n", symbol.raw->string);
 	auto node = stabs_type_to_ast_and_handle_errors(*symbol.name_colon_type.type.get(), state, 0, 0, false, false);
 	node->name = (symbol.name_colon_type.name == " ") ? "" : symbol.name_colon_type.name;
-	node->symbol = &symbol;
 	if(symbol.name_colon_type.descriptor == StabsSymbolDescriptor::TYPE_NAME) {
 		node->storage_class = ast::SC_TYPEDEF;
 	}

--- a/stdump.cpp
+++ b/stdump.cpp
@@ -108,7 +108,7 @@ int main(int argc, char** argv) {
 			Result<mdebug::SymbolTable> symbol_table = read_symbol_table(mod, options.input_file);
 			CCC_EXIT_IF_ERROR(symbol_table);
 			
-			mdebug::print_headers(out, *symbol_table);
+			symbol_table->print_header(out);
 			break;
 		}
 		case OutputMode::SYMBOLS: {
@@ -171,21 +171,27 @@ static Result<mdebug::SymbolTable> read_symbol_table(Module& mod, const fs::path
 	std::optional<std::vector<u8>> binary = platform::read_binary_file(input_file);
 	CCC_CHECK(binary.has_value(), "Failed to open file '%s'.", input_file.string().c_str());
 	mod.image = std::move(*binary);
-	Result<void> result = parse_elf_file(mod);
-	CCC_RETURN_IF_ERROR(result);
+	
+	Result<void> elf_result = parse_elf_file(mod);
+	CCC_RETURN_IF_ERROR(elf_result);
 	
 	ModuleSection* mdebug_section = mod.lookup_section(".mdebug");
 	CCC_CHECK(mdebug_section != nullptr, "No .mdebug section.");
 	
-	return mdebug::parse_symbol_table(mod.image, mdebug_section->file_offset);
+	mdebug::SymbolTable symbol_table;
+	Result<void> symbol_table_result = symbol_table.init(mod.image, mdebug_section->file_offset);
+	CCC_EXIT_IF_ERROR(symbol_table_result);
+	
+	return symbol_table;
 }
 
 static void print_functions(FILE* out, mdebug::SymbolTable& symbol_table) {
 	CppPrinter printer(out);
-	for(s32 i = 0; i < (s32) symbol_table.files.size(); i++) {
-		Result<HighSymbolTable> result = analyse(symbol_table, NO_ANALYSIS_FLAGS, i);
-		CCC_EXIT_IF_ERROR(result);
-		ast::SourceFile& source_file = *result->source_files.at(0);
+	s32 file_count = symbol_table.file_count();
+	for(s32 i = 0; i < file_count; i++) {
+		Result<HighSymbolTable> high = analyse(symbol_table, NO_ANALYSIS_FLAGS, i);
+		CCC_EXIT_IF_ERROR(high);
+		ast::SourceFile& source_file = *high->source_files.at(0);
 		printer.comment_block_file(source_file.full_path.c_str());
 		for(const std::unique_ptr<ast::Node>& node : source_file.functions) {
 			printer.function(node->as<ast::FunctionDefinition>());
@@ -195,10 +201,11 @@ static void print_functions(FILE* out, mdebug::SymbolTable& symbol_table) {
 
 static void print_globals(FILE* out, mdebug::SymbolTable& symbol_table) {
 	CppPrinter printer(out);
-	for(s32 i = 0; i < (s32) symbol_table.files.size(); i++) {
-		Result<HighSymbolTable> result = analyse(symbol_table, NO_ANALYSIS_FLAGS, i);
-		CCC_EXIT_IF_ERROR(result);
-		ast::SourceFile& source_file = *result->source_files.at(0);
+	s32 file_count = symbol_table.file_count();
+	for(s32 i = 0; i < file_count; i++) {
+		Result<HighSymbolTable> high = analyse(symbol_table, NO_ANALYSIS_FLAGS, i);
+		CCC_EXIT_IF_ERROR(high);
+		ast::SourceFile& source_file = *high->source_files.at(0);
 		printer.comment_block_file(source_file.full_path.c_str());
 		for(const std::unique_ptr<ast::Node>& node : source_file.globals) {
 			printer.global_variable(node->as<ast::Variable>());
@@ -213,7 +220,7 @@ static void print_types_deduplicated(FILE* out, mdebug::SymbolTable& symbol_tabl
 	CCC_EXIT_IF_ERROR(high);
 	CppPrinter printer(out);
 	printer.comment_block_beginning(options.input_file.filename().string().c_str());
-	printer.comment_block_compiler_version_info(symbol_table);
+	printer.comment_block_toolchain_version_info(*high);
 	printer.comment_block_builtin_types((*high).deduplicated_types);
 	for(const std::unique_ptr<ast::Node>& type : high->deduplicated_types) {
 		printer.data_type(*type);
@@ -224,12 +231,14 @@ static void print_types_per_file(FILE* out, mdebug::SymbolTable& symbol_table, c
 	u32 analysis_flags = build_analysis_flags(options.flags);
 	CppPrinter printer(out);
 	printer.comment_block_beginning(options.input_file.filename().string().c_str());
-	for(s32 i = 0; i < (s32) symbol_table.files.size(); i++) {
-		Result<HighSymbolTable> result = analyse(symbol_table, analysis_flags, i);
-		CCC_EXIT_IF_ERROR(result);
-		ast::SourceFile& source_file = *result->source_files.at(0);
+	
+	s32 file_count = symbol_table.file_count();
+	for(s32 i = 0; i < file_count; i++) {
+		Result<HighSymbolTable> high = analyse(symbol_table, analysis_flags, i);
+		CCC_EXIT_IF_ERROR(high);
+		ast::SourceFile& source_file = *high->source_files.at(0);
 		printer.comment_block_file(source_file.full_path.c_str());
-		printer.comment_block_compiler_version_info(symbol_table);
+		printer.comment_block_toolchain_version_info(*high);
 		printer.comment_block_builtin_types(source_file.data_types);
 		for(const std::unique_ptr<ast::Node>& type : source_file.data_types) {
 			printer.data_type(*type);
@@ -238,16 +247,23 @@ static void print_types_per_file(FILE* out, mdebug::SymbolTable& symbol_table, c
 }
 
 static void print_local_symbols(FILE* out, const mdebug::SymbolTable& symbol_table) {
-	for(const mdebug::SymFileDescriptor& fd : symbol_table.files) {
-		fprintf(out, "FILE %s:\n", fd.raw_path.c_str());
-		for(const mdebug::Symbol& symbol : fd.symbols) {
+	s32 file_count = symbol_table.file_count();
+	for(s32 i = 0; i < file_count; i++) {
+		Result<mdebug::File> file = symbol_table.parse_file(i);
+		CCC_EXIT_IF_ERROR(file);
+		
+		fprintf(out, "FILE %s:\n", file->raw_path.c_str());
+		for(const mdebug::Symbol& symbol : file->symbols) {
 			print_symbol(out, symbol, true);
 		}
 	}
 }
 
 static void print_external_symbols(FILE* out, const mdebug::SymbolTable& symbol_table) {
-	for(const mdebug::Symbol& symbol : symbol_table.externals) {
+	Result<std::vector<mdebug::Symbol>> external_symbols = symbol_table.parse_external_symbols();
+	CCC_EXIT_IF_ERROR(external_symbols);
+	
+	for(const mdebug::Symbol& symbol : *external_symbols) {
 		print_symbol(out, symbol, false);
 	}
 }
@@ -288,8 +304,12 @@ static u32 build_analysis_flags(u32 flags) {
 }
 
 static void list_files(FILE* out, const mdebug::SymbolTable& symbol_table) {
-	for(const mdebug::SymFileDescriptor& fd : symbol_table.files) {
-		fprintf(out, "%s\n", fd.full_path.c_str());
+	s32 file_count = symbol_table.file_count();
+	for(s32 i = 0; i < file_count; i++) {
+		Result<mdebug::File> file = symbol_table.parse_file(i);
+		CCC_EXIT_IF_ERROR(file);
+		
+		fprintf(out, "%s\n", file->full_path.c_str());
 	}
 }
 
@@ -303,24 +323,29 @@ static void list_sections(FILE* out, const mdebug::SymbolTable& symbol_table, co
 		u32 section_end = section.virtual_address + section.size;
 		
 		fprintf(out, "%s:\n", section.name.c_str());
-		for(const mdebug::SymFileDescriptor& fd : symbol_table.files) {
+		
+		s32 file_count = symbol_table.file_count();
+		for(s32 i = 0; i < file_count; i++) {
+			Result<mdebug::File> file = symbol_table.parse_file(i);
+			CCC_EXIT_IF_ERROR(file);
+			
 			// Find the text address without running the whole analysis process.
 			u32 text_address = UINT32_MAX;
-			for(const mdebug::Symbol& symbol : fd.symbols) {
+			for(const mdebug::Symbol& symbol : file->symbols) {
 				if(symbol.is_stabs && symbol.code == mdebug::N_SO) {
 					text_address = symbol.value;
 					break;
 				}
 			}
 			if(text_address == UINT32_MAX) {
-				for(const mdebug::Symbol& symbol : fd.symbols) {
+				for(const mdebug::Symbol& symbol : file->symbols) {
 					if(symbol.storage_type == mdebug::SymbolType::PROC && symbol.storage_class == mdebug::SymbolClass::TEXT && symbol.value != -1) {
 						text_address = std::min(text_address, (u32) symbol.value);
 					}
 				}
 			}
 			if(text_address != UINT32_MAX && text_address >= section_start && text_address < section_end) {
-				fprintf(out, "\t%s\n", fd.full_path.c_str());
+				fprintf(out, "\t%s\n", file->full_path.c_str());
 			}
 		}
 	}
@@ -340,15 +365,16 @@ static void test(FILE* out, const fs::path& directory) {
 			
 			Module mod;
 			mod.image = std::move(*binary);
-			Result<void> result = parse_elf_file(mod);
-			CCC_EXIT_IF_ERROR(result);
+			Result<void> elf_result = parse_elf_file(mod);
+			CCC_EXIT_IF_ERROR(elf_result);
 			
 			ModuleSection* mdebug_section = mod.lookup_section(".mdebug");
 			if(mdebug_section) {
-				Result<mdebug::SymbolTable> symbol_table = mdebug::parse_symbol_table(mod.image, mdebug_section->file_offset);
-				CCC_EXIT_IF_ERROR(symbol_table);
+				mdebug::SymbolTable symbol_table;
+				Result<void> symbol_table_result = symbol_table.init(mod.image, (s32) mdebug_section->file_offset);
+				CCC_EXIT_IF_ERROR(symbol_table_result);
 				
-				Result<ccc::HighSymbolTable> high = analyse(*symbol_table, DEDUPLICATE_TYPES);
+				Result<ccc::HighSymbolTable> high = analyse(symbol_table, DEDUPLICATE_TYPES);
 				CCC_EXIT_IF_ERROR(high);
 				
 				CppPrinter printer(out);

--- a/stdump.cpp
+++ b/stdump.cpp
@@ -24,10 +24,9 @@ enum class OutputMode {
 enum Flags {
 	NO_FLAGS = 0,
 	FLAG_PER_FILE = (1 << 0),
-	FLAG_VERBOSE = (1 << 1),
-	FLAG_OMIT_ACCESS_SPECIFIERS = (1 << 2),
-	FLAG_OMIT_MEMBER_FUNCTIONS = (1 << 3),
-	FLAG_INCLUDE_GENERATED_FUNCTIONS = (1 << 4)
+	FLAG_OMIT_ACCESS_SPECIFIERS = (1 << 1),
+	FLAG_OMIT_MEMBER_FUNCTIONS = (1 << 2),
+	FLAG_INCLUDE_GENERATED_FUNCTIONS = (1 << 3)
 };
 
 struct Options {
@@ -216,7 +215,6 @@ static void print_types_deduplicated(FILE* out, mdebug::SymbolTable& symbol_tabl
 	printer.comment_block_beginning(options.input_file.filename().string().c_str());
 	printer.comment_block_compiler_version_info(symbol_table);
 	printer.comment_block_builtin_types((*high).deduplicated_types);
-	printer.verbose = options.flags & FLAG_VERBOSE;
 	for(const std::unique_ptr<ast::Node>& type : high->deduplicated_types) {
 		printer.data_type(*type);
 	}
@@ -225,7 +223,6 @@ static void print_types_deduplicated(FILE* out, mdebug::SymbolTable& symbol_tabl
 static void print_types_per_file(FILE* out, mdebug::SymbolTable& symbol_table, const Options& options) {
 	u32 analysis_flags = build_analysis_flags(options.flags);
 	CppPrinter printer(out);
-	printer.verbose = options.flags & FLAG_VERBOSE;
 	printer.comment_block_beginning(options.input_file.filename().string().c_str());
 	for(s32 i = 0; i < (s32) symbol_table.files.size(); i++) {
 		Result<HighSymbolTable> result = analyse(symbol_table, analysis_flags, i);
@@ -234,7 +231,6 @@ static void print_types_per_file(FILE* out, mdebug::SymbolTable& symbol_table, c
 		printer.comment_block_file(source_file.full_path.c_str());
 		printer.comment_block_compiler_version_info(symbol_table);
 		printer.comment_block_builtin_types(source_file.data_types);
-		printer.verbose = options.flags & FLAG_VERBOSE;
 		for(const std::unique_ptr<ast::Node>& type : source_file.data_types) {
 			printer.data_type(*type);
 		}
@@ -429,8 +425,6 @@ static Options parse_args(int argc, char** argv) {
 		const char* arg = argv[i];
 		if(strcmp(arg, "--per-file") == 0) {
 			options.flags |= FLAG_PER_FILE;
-		} else if(strcmp(arg, "--verbose") == 0) {
-			options.flags |= FLAG_VERBOSE;
 		} else if(strcmp(arg, "--omit-access-specifiers") == 0) {
 			options.flags |= FLAG_OMIT_ACCESS_SPECIFIERS;
 		} else if(strcmp(arg, "--omit-member-functions") == 0) {
@@ -477,8 +471,6 @@ static void print_help() {
 	puts("    Print all the types recovered from the STABS symbols as C++.");
 	puts("");
 	puts("    --per-file                    Do not deduplicate types from files.");
-	puts("    --verbose                     Print additional information such as the raw");
-	puts("                                  STABS symbol along with each type.");
 	puts("    --omit-access-specifiers      Do not print access specifiers.");
 	puts("    --omit-member-functions       Do not print member functions.");
 	puts("    --include-generated-functions Include member functions that are likely");


### PR DESCRIPTION
Gets it down by over a half.