### PR TITLE
Add support for multiple program modules in a single symbol database

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Use of a code formatter such as `clang-format` or `astyle` on the output is reco
 
 | Format Version | Release | Changes |
 | - | - | - |
+| 10 | | Added modules as their own symbol type. Removed the text_address property of source file symbols. |
 | 9 | | Added optional is_virtual_base_class property to nodes in base class lists. |
 | 8 | | Overhauled the format based on the structure of the new symbol database. An error AST node type has been added. The data, function definition, initializer list, source file and variable AST node types have been removed and replaced. |
 | 7 | v1.x | Base classes are now no longer doubly nested inside two JSON objects. Added acccess_specifier property. |

--- a/src/ccc/elf.cpp
+++ b/src/ccc/elf.cpp
@@ -161,7 +161,7 @@ Result<void> import_elf_section_headers(
 	return Result<void>();
 }
 
-Result<void> read_virtual(u8* dest, u32 address, u32 size, const std::vector<ElfFile*>& elves)
+Result<void> read_virtual(u8* dest, u32 address, u32 size, const std::vector<const ElfFile*>& elves)
 {
 	while(size > 0) {
 		bool mapped = false;

--- a/src/ccc/elf.cpp
+++ b/src/ccc/elf.cpp
@@ -149,10 +149,10 @@ Result<ElfFile> parse_elf_file(std::vector<u8> image)
 }
 
 Result<void> import_elf_section_headers(
-	SymbolDatabase& database, const ElfFile& elf, SymbolSourceHandle source)
+	SymbolDatabase& database, const ElfFile& elf, SymbolSourceHandle source, const Module* module_symbol)
 {
 	for(const ElfSection& section : elf.sections) {
-		Result<Section*> symbol = database.sections.create_symbol(section.name, source, section.address);
+		Result<Section*> symbol = database.sections.create_symbol(section.name, source, module_symbol, section.address);
 		CCC_RETURN_IF_ERROR(symbol);
 		
 		(*symbol)->set_size(section.size);

--- a/src/ccc/elf.h
+++ b/src/ccc/elf.h
@@ -57,7 +57,7 @@ struct ElfFile {
 // Parse the ELF file header, section headers and program headers.
 Result<ElfFile> parse_elf_file(std::vector<u8> image);
 
-Result<void> import_elf_section_headers(SymbolDatabase& database, const ElfFile& elf, SymbolSourceHandle source);
+Result<void> import_elf_section_headers(SymbolDatabase& database, const ElfFile& elf, SymbolSourceHandle source, const Module* module_symbol);
 
 Result<void> read_virtual(u8* dest, u32 address, u32 size, const std::vector<ElfFile*>& elves);
 

--- a/src/ccc/elf.h
+++ b/src/ccc/elf.h
@@ -59,10 +59,10 @@ Result<ElfFile> parse_elf_file(std::vector<u8> image);
 
 Result<void> import_elf_section_headers(SymbolDatabase& database, const ElfFile& elf, SymbolSourceHandle source, const Module* module_symbol);
 
-Result<void> read_virtual(u8* dest, u32 address, u32 size, const std::vector<ElfFile*>& elves);
+Result<void> read_virtual(u8* dest, u32 address, u32 size, const std::vector<const ElfFile*>& elves);
 
 template <typename T>
-Result<std::vector<T>> read_virtual_vector(u32 address, u32 count, const std::vector<ElfFile*>& elves)
+Result<std::vector<T>> read_virtual_vector(u32 address, u32 count, const std::vector<const ElfFile*>& elves)
 {
 	std::vector<T> vector(count);
 	Result<void> result = read_virtual((u8*) vector.data(), address, count * sizeof(T), elves);

--- a/src/ccc/elf_symtab.cpp
+++ b/src/ccc/elf_symtab.cpp
@@ -54,6 +54,7 @@ static const char* symbol_visibility_to_string(SymbolVisibility visibility);
 Result<void> import_symbols(
 	SymbolDatabase& database,
 	SymbolSourceHandle source,
+	const Module* module_symbol,
 	std::span<const u8> symtab,
 	std::span<const u8> strtab,
 	u32 importer_flags,
@@ -78,13 +79,14 @@ Result<void> import_symbols(
 		switch(symbol->type()) {
 			case SymbolType::NOTYPE: {
 				Result<Label*> label = database.labels.create_symbol(
-					string, source, address, importer_flags, demangler);
+					string, source, module_symbol, address, importer_flags, demangler);
 				CCC_RETURN_IF_ERROR(label);
+				
 				break;
 			}
 			case SymbolType::OBJECT: {
 				Result<GlobalVariable*> global_variable = database.global_variables.create_symbol(
-					string, source, address, importer_flags, demangler);
+					string, source, module_symbol, address, importer_flags, demangler);
 				CCC_RETURN_IF_ERROR(global_variable);
 				
 				if(*global_variable) {
@@ -95,7 +97,7 @@ Result<void> import_symbols(
 			}
 			case SymbolType::FUNC: {
 				Result<Function*> function = database.functions.create_symbol(
-					string, source, address, importer_flags, demangler);
+					string, source, module_symbol, address, importer_flags, demangler);
 				CCC_RETURN_IF_ERROR(function);
 				
 				if(*function) {
@@ -105,7 +107,7 @@ Result<void> import_symbols(
 				break;
 			}
 			case SymbolType::FILE: {
-				Result<SourceFile*> source_file = database.source_files.create_symbol(string, source);
+				Result<SourceFile*> source_file = database.source_files.create_symbol(string, source, module_symbol);
 				CCC_RETURN_IF_ERROR(source_file);
 				
 				break;

--- a/src/ccc/elf_symtab.h
+++ b/src/ccc/elf_symtab.h
@@ -10,6 +10,7 @@ namespace ccc::elf {
 Result<void> import_symbols(
 	SymbolDatabase& database,
 	SymbolSourceHandle source,
+	const Module* module_symbol,
 	std::span<const u8> symtab,
 	std::span<const u8> strtab,
 	u32 importer_flags,

--- a/src/ccc/mdebug_analysis.cpp
+++ b/src/ccc/mdebug_analysis.cpp
@@ -43,7 +43,8 @@ Result<void> LocalSymbolTableAnalyser::data_type(const ParsedSymbol& symbol)
 	StabsTypeNumber number = symbol.name_colon_type.type->type_number;
 	
 	if(m_context.importer_flags & DONT_DEDUPLICATE_TYPES) {
-		Result<DataType*> data_type = m_database.data_types.create_symbol(name, m_context.symbol_source);
+		Result<DataType*> data_type = m_database.data_types.create_symbol(
+			name, m_context.symbol_source, m_context.module_symbol);
 		CCC_RETURN_IF_ERROR(data_type);
 		
 		m_source_file.stabs_type_number_to_handle[number] = (*data_type)->handle();
@@ -52,7 +53,7 @@ Result<void> LocalSymbolTableAnalyser::data_type(const ParsedSymbol& symbol)
 		(*data_type)->files = {m_source_file.handle()};
 	} else {
 		Result<ccc::DataType*> type = m_database.create_data_type_if_unique(
-			std::move(*node), number, name, m_source_file, m_context.symbol_source);
+			std::move(*node), number, name, m_source_file, m_context.symbol_source, m_context.module_symbol);
 		CCC_RETURN_IF_ERROR(type);
 	}
 	
@@ -63,13 +64,11 @@ Result<void> LocalSymbolTableAnalyser::global_variable(
 	const char* mangled_name, Address address, const StabsType& type, bool is_static, GlobalStorageLocation location)
 {
 	Result<GlobalVariable*> global = m_database.global_variables.create_symbol(
-		mangled_name, m_context.symbol_source, address, m_context.importer_flags, m_context.demangler);
+		mangled_name, m_context.symbol_source, m_context.module_symbol, address, m_context.importer_flags, m_context.demangler);
 	CCC_RETURN_IF_ERROR(global);
 	CCC_ASSERT(*global);
 	
 	m_global_variables.expand_to_include((*global)->handle());
-	
-	
 	
 	Result<std::unique_ptr<ast::Node>> node = stabs_type_to_ast(type, nullptr, m_stabs_to_ast_state, 0, true, false);
 	CCC_RETURN_IF_ERROR(node);
@@ -171,8 +170,10 @@ Result<void> LocalSymbolTableAnalyser::parameter(
 {
 	CCC_CHECK(m_current_function, "Parameter symbol before first func/proc symbol.");
 	
-	Result<ParameterVariable*> parameter_variable = m_database.parameter_variables.create_symbol(name, m_context.symbol_source);
+	Result<ParameterVariable*> parameter_variable = m_database.parameter_variables.create_symbol(
+		name, m_context.symbol_source, m_context.module_symbol);
 	CCC_RETURN_IF_ERROR(parameter_variable);
+	
 	m_current_parameter_variables.expand_to_include((*parameter_variable)->handle());
 	
 	Result<std::unique_ptr<ast::Node>> node = stabs_type_to_ast(type, nullptr, m_stabs_to_ast_state, 0, true, true);
@@ -199,8 +200,10 @@ Result<void> LocalSymbolTableAnalyser::local_variable(
 	}
 	
 	Address address = (desc == StabsSymbolDescriptor::STATIC_LOCAL_VARIABLE) ? value : Address();
-	Result<LocalVariable*> local_variable = m_database.local_variables.create_symbol(name, m_context.symbol_source, address);
+	Result<LocalVariable*> local_variable = m_database.local_variables.create_symbol(
+		name, m_context.symbol_source, m_context.module_symbol, address);
 	CCC_RETURN_IF_ERROR(local_variable);
+	
 	m_current_local_variables.expand_to_include((*local_variable)->handle());
 	m_pending_local_variables.emplace_back((*local_variable)->handle());
 	
@@ -285,7 +288,7 @@ Result<void> LocalSymbolTableAnalyser::create_function(const char* mangled_name,
 	}
 	
 	Result<Function*> function = m_database.functions.create_symbol(
-		mangled_name, m_context.symbol_source, address, m_context.importer_flags, m_context.demangler);
+		mangled_name, m_context.symbol_source, m_context.module_symbol, address, m_context.importer_flags, m_context.demangler);
 	CCC_RETURN_IF_ERROR(function);
 	CCC_ASSERT(*function);
 	m_current_function = *function;

--- a/src/ccc/mdebug_analysis.cpp
+++ b/src/ccc/mdebug_analysis.cpp
@@ -14,7 +14,6 @@ Result<void> LocalSymbolTableAnalyser::stab_magic(const char* magic)
 
 Result<void> LocalSymbolTableAnalyser::source_file(const char* path, Address text_address)
 {
-	m_source_file.text_address = text_address;
 	if(m_next_relative_path.empty()) {
 		m_next_relative_path = m_source_file.command_line_path;
 	}
@@ -238,7 +237,7 @@ Result<void> LocalSymbolTableAnalyser::lbrac(s32 begin_offset)
 {
 	for(LocalVariableHandle local_variable_handle : m_pending_local_variables) {
 		if(LocalVariable* local_variable = m_database.local_variables.symbol_from_handle(local_variable_handle)) {
-			local_variable->live_range.low = m_source_file.text_address.value + begin_offset;
+			local_variable->live_range.low = m_source_file.address().value + begin_offset;
 		}
 	}
 	
@@ -255,7 +254,7 @@ Result<void> LocalSymbolTableAnalyser::rbrac(s32 end_offset)
 	std::vector<LocalVariableHandle>& variables = m_blocks.back();
 	for(LocalVariableHandle local_variable_handle : variables) {
 		if(LocalVariable* local_variable = m_database.local_variables.symbol_from_handle(local_variable_handle)) {
-			local_variable->live_range.high = m_source_file.text_address.value + end_offset;
+			local_variable->live_range.high = m_source_file.address().value + end_offset;
 		}
 	}
 	

--- a/src/ccc/mdebug_analysis.h
+++ b/src/ccc/mdebug_analysis.h
@@ -16,6 +16,7 @@ struct AnalysisContext {
 	const mdebug::SymbolTableReader* reader = nullptr;
 	const std::map<std::string, const mdebug::Symbol*>* globals;
 	SymbolSourceHandle symbol_source;
+	const Module* module_symbol;
 	u32 importer_flags = NO_IMPORTER_FLAGS;
 	DemanglerFunctions demangler;
 };

--- a/src/ccc/mdebug_analysis.h
+++ b/src/ccc/mdebug_analysis.h
@@ -16,7 +16,7 @@ struct AnalysisContext {
 	const mdebug::SymbolTableReader* reader = nullptr;
 	const std::map<std::string, const mdebug::Symbol*>* globals;
 	SymbolSourceHandle symbol_source;
-	const Module* module_symbol;
+	const Module* module_symbol = nullptr;
 	u32 importer_flags = NO_IMPORTER_FLAGS;
 	DemanglerFunctions demangler;
 };

--- a/src/ccc/mdebug_importer.h
+++ b/src/ccc/mdebug_importer.h
@@ -16,6 +16,7 @@ Result<void> import_symbol_table(
 	std::span<const u8> elf,
 	s32 section_offset,
 	SymbolSourceHandle source,
+	const Module* module_symbol,
 	u32 importer_flags,
 	const DemanglerFunctions& demangler);
 Result<void> import_files(SymbolDatabase& database, const AnalysisContext& context);

--- a/src/ccc/mdebug_symbols.cpp
+++ b/src/ccc/mdebug_symbols.cpp
@@ -60,7 +60,8 @@ Result<std::vector<ParsedSymbol>> parse_symbols(const std::vector<mdebug::Symbol
 								CCC_WARN("%s Symbol string: %s", STAB_TRUNCATED_ERROR_MESSAGE, string);
 								importer_flags &= ~STRICT_PARSING;
 							} else {
-								return parse_result;
+								return CCC_FAILURE("%s Symbol string: %s",
+									parse_result.error().message.c_str(), string);
 							}
 						}
 					} else {

--- a/src/ccc/sndll.cpp
+++ b/src/ccc/sndll.cpp
@@ -113,6 +113,7 @@ Result<void> import_sndll_symbols(
 	SymbolDatabase& database,
 	const SNDLLFile& sndll,
 	SymbolSourceHandle source,
+	const Module* module_symbol,
 	u32 importer_flags,
 	DemanglerFunctions demangler)
 {
@@ -121,15 +122,17 @@ Result<void> import_sndll_symbols(
 			switch(symbol.type) {
 				case SNDLLSymbolType::RELATIVE:
 				case SNDLLSymbolType::WEAK: {
-					Result<Label*> result = database.labels.create_symbol(
-						symbol.string, source, sndll.address.get_or_zero() + symbol.value, importer_flags, demangler);
-					CCC_RETURN_IF_ERROR(result);
+					Result<Label*> label = database.labels.create_symbol(
+						symbol.string, source, module_symbol, sndll.address.get_or_zero() + symbol.value, importer_flags, demangler);
+					CCC_RETURN_IF_ERROR(label);
+					
 					break;
 				}
 				case SNDLLSymbolType::ABSOLUTE: {
-					Result<Label*> result = database.labels.create_symbol(
-						symbol.string, source, symbol.value, importer_flags, demangler);
-					CCC_RETURN_IF_ERROR(result);
+					Result<Label*> label = database.labels.create_symbol(
+						symbol.string, source, module_symbol,symbol.value, importer_flags, demangler);
+					CCC_RETURN_IF_ERROR(label);
+					
 					break;
 				}
 				case SNDLLSymbolType::NIL:

--- a/src/ccc/sndll.h
+++ b/src/ccc/sndll.h
@@ -41,6 +41,7 @@ Result<void> import_sndll_symbols(
 	SymbolDatabase& database,
 	const SNDLLFile& sndll,
 	SymbolSourceHandle source,
+	const Module* module_symbol,
 	u32 importer_flags,
 	DemanglerFunctions demangler);
 

--- a/src/ccc/symbol_database.cpp
+++ b/src/ccc/symbol_database.cpp
@@ -188,7 +188,7 @@ s32 SymbolList<SymbolType>::size() const
 
 template <typename SymbolType>
 Result<SymbolType*> SymbolList<SymbolType>::create_symbol(
-	std::string name, SymbolSourceHandle source, Address address, u32 importer_flags, DemanglerFunctions demangler)
+	std::string name, SymbolSourceHandle source, const Module* module_symbol, Address address, u32 importer_flags, DemanglerFunctions demangler)
 {
 	static const int DMGL_PARAMS = 1 << 0;
 	static const int DMGL_RET_POSTFIX = 1 << 5;
@@ -221,7 +221,7 @@ Result<SymbolType*> SymbolList<SymbolType>::create_symbol(
 		}
 	}
 	
-	Result<SymbolType*> symbol = create_symbol(non_mangled_name, source, address);
+	Result<SymbolType*> symbol = create_symbol(non_mangled_name, source, module_symbol, address);
 	CCC_RETURN_IF_ERROR(symbol);
 	
 	if constexpr(SymbolType::FLAGS & NAME_NEEDS_DEMANGLING) {
@@ -234,7 +234,8 @@ Result<SymbolType*> SymbolList<SymbolType>::create_symbol(
 }
 
 template <typename SymbolType>
-Result<SymbolType*> SymbolList<SymbolType>::create_symbol(std::string name, SymbolSourceHandle source, Address address)
+Result<SymbolType*> SymbolList<SymbolType>::create_symbol(
+	std::string name, SymbolSourceHandle source, const Module* module_symbol, Address address)
 {
 	CCC_CHECK(m_next_handle != UINT32_MAX, "Failed to allocate space for %s symbol.", SymbolType::NAME);
 	
@@ -244,7 +245,6 @@ Result<SymbolType*> SymbolList<SymbolType>::create_symbol(std::string name, Symb
 	
 	symbol.m_handle = handle;
 	symbol.m_name = std::move(name);
-	symbol.m_address = address;
 	
 	if constexpr(std::is_same_v<SymbolType, SymbolSource>) {
 		// It doesn't make sense for the calling code to provide a symbol source
@@ -254,6 +254,19 @@ Result<SymbolType*> SymbolList<SymbolType>::create_symbol(std::string name, Symb
 	} else {
 		CCC_ASSERT(source.valid());
 		symbol.m_source = source;
+	}
+	
+	if constexpr(std::is_same_v<SymbolType, Module>) {
+		// It doesn't make sense for the calling code to provide a module as an
+		// argument if we're creating a module symbol, so we set the module of
+		// the new symbol to its own handle.
+		symbol.m_address = address;
+		symbol.m_module = handle;
+	} else if(module_symbol) {
+		symbol.m_address = address.add_base_address(module_symbol->address().value);
+		symbol.m_module = module_symbol->handle();
+	} else {
+		symbol.m_address = address;
 	}
 	
 	link_address_map(symbol);
@@ -322,13 +335,30 @@ u32 SymbolList<SymbolType>::destroy_symbols(SymbolRange<SymbolType> range)
 }
 
 template <typename SymbolType>
-void SymbolList<SymbolType>::destroy_symbols_from_sources(SymbolSourceRange sources)
+void SymbolList<SymbolType>::destroy_symbols_from_sources(SymbolSourceRange source_range)
 {
 	for(size_t i = 0; i < m_symbols.size(); i++) {
-		if(m_symbols[i].m_source >= sources.first && m_symbols[i].m_source <= sources.last) {
+		if(m_symbols[i].m_source >= source_range.first && m_symbols[i].m_source <= source_range.last) {
 			size_t end;
 			for(end = i + 1; end < m_symbols.size(); end++) {
-				if(m_symbols[i].m_source >= sources.first && m_symbols[i].m_source <= sources.last) {
+				if(m_symbols[i].m_source >= source_range.first && m_symbols[i].m_source <= source_range.last) {
+					break;
+				}
+			}
+			destroy_symbols_impl(i, end);
+			i--;
+		}
+	}
+}
+
+template <typename SymbolType>
+void SymbolList<SymbolType>::destroy_symbols_from_modules(ModuleRange module_range)
+{
+	for(size_t i = 0; i < m_symbols.size(); i++) {
+		if(m_symbols[i].m_module >= module_range.first && m_symbols[i].m_module <= module_range.last) {
+			size_t end;
+			for(end = i + 1; end < m_symbols.size(); end++) {
+				if(m_symbols[i].m_module >= module_range.first && m_symbols[i].m_module <= module_range.last) {
 					break;
 				}
 			}
@@ -568,6 +598,17 @@ bool SymbolDatabase::symbol_exists_with_starting_address(Address address) const
 	return false;
 }
 
+Result<SymbolSourceHandle> SymbolDatabase::get_symbol_source(const std::string& name)
+{
+	SymbolSourceHandle handle = symbol_sources.first_handle_from_name(name);
+	if(!handle.valid()) {
+		Result<SymbolSource*> source = symbol_sources.create_symbol(name, SymbolSourceHandle(), nullptr);
+		CCC_RETURN_IF_ERROR(source);
+		handle = (*source)->handle();
+	}
+	return handle;
+}
+
 void SymbolDatabase::clear()
 {
 	#define CCC_X(SymbolType, symbol_list) symbol_list.clear();
@@ -575,9 +616,16 @@ void SymbolDatabase::clear()
 	#undef CCC_X
 }
 
-void SymbolDatabase::destroy_symbols_from_sources(SymbolSourceRange sources)
+void SymbolDatabase::destroy_symbols_from_sources(SymbolSourceRange source_range)
 {
-	#define CCC_X(SymbolType, symbol_list) symbol_list.destroy_symbols_from_sources(sources);
+	#define CCC_X(SymbolType, symbol_list) symbol_list.destroy_symbols_from_sources(source_range);
+	CCC_FOR_EACH_SYMBOL_TYPE_DO_X
+	#undef CCC_X
+}
+
+void SymbolDatabase::destroy_symbols_from_modules(ModuleRange module_range)
+{
+	#define CCC_X(SymbolType, symbol_list) symbol_list.destroy_symbols_from_modules(module_range);
 	CCC_FOR_EACH_SYMBOL_TYPE_DO_X
 	#undef CCC_X
 }
@@ -587,13 +635,14 @@ Result<DataType*> SymbolDatabase::create_data_type_if_unique(
 	StabsTypeNumber number,
 	const char* name,
 	SourceFile& source_file,
-	SymbolSourceHandle source)
+	SymbolSourceHandle source,
+	const Module* module_symbol)
 {
 	auto types_with_same_name = data_types.handles_from_name(name);
 	const char* compare_fail_reason = nullptr;
 	if(types_with_same_name.begin() == types_with_same_name.end()) {
 		// No types with this name have previously been processed.
-		Result<DataType*> data_type = data_types.create_symbol(name, source);
+		Result<DataType*> data_type = data_types.create_symbol(name, source, module_symbol);
 		CCC_RETURN_IF_ERROR(data_type);
 		
 		(*data_type)->files = {source_file.handle()};
@@ -617,6 +666,19 @@ Result<DataType*> SymbolDatabase::create_data_type_if_unique(
 			// anything else.
 			if(existing_type->source() != source) {
 				continue;
+			}
+			
+			// We don't want to merge together types from different modules so
+			// we can destroy all the types from one module without breaking
+			// anything else.
+			if(module_symbol) {
+				if(existing_type->module_handle() != module_symbol->module_handle()) {
+					continue;
+				}
+			} else {
+				if(existing_type->module_handle().valid()) {
+					continue;
+				}
 			}
 			
 			CCC_ASSERT(existing_type->type());
@@ -647,7 +709,7 @@ Result<DataType*> SymbolDatabase::create_data_type_if_unique(
 		if(!match) {
 			// This type doesn't match the others with the same name that have
 			// already been processed.
-			Result<DataType*> data_type = data_types.create_symbol(name, source);
+			Result<DataType*> data_type = data_types.create_symbol(name, source, module_symbol);
 			CCC_RETURN_IF_ERROR(data_type);
 			
 			(*data_type)->files = {source_file.handle()};

--- a/src/ccc/symbol_database.cpp
+++ b/src/ccc/symbol_database.cpp
@@ -263,7 +263,7 @@ Result<SymbolType*> SymbolList<SymbolType>::create_symbol(
 		symbol.m_address = address;
 		symbol.m_module = handle;
 	} else if(module_symbol) {
-		symbol.m_address = address.add_base_address(module_symbol->address().value);
+		symbol.m_address = address.add_base_address(module_symbol->address());
 		symbol.m_module = module_symbol->handle();
 	} else {
 		symbol.m_address = address;

--- a/src/ccc/symbol_database.h
+++ b/src/ccc/symbol_database.h
@@ -478,7 +478,7 @@ class SourceFile : public Symbol {
 public:
 	static constexpr const SymbolDescriptor DESCRIPTOR = SymbolDescriptor::SOURCE_FILE;
 	static constexpr const char* NAME = "Source File";
-	static constexpr u32 FLAGS = NO_SYMBOL_FLAGS;
+	static constexpr u32 FLAGS = WITH_ADDRESS_MAP | WITH_NAME_MAP;
 	
 	SourceFileHandle handle() const { return m_handle; }
 	const std::string& full_path() const { return name(); }
@@ -491,7 +491,6 @@ public:
 	
 	std::string working_dir;
 	std::string command_line_path;
-	Address text_address = 0;
 	std::map<StabsTypeNumber, DataTypeHandle> stabs_type_number_to_handle;
 	std::set<std::string> toolchain_version_info;
 	

--- a/src/ccc/symbol_database.h
+++ b/src/ccc/symbol_database.h
@@ -326,6 +326,7 @@ struct StackStorage {
 
 // All the different types of symbol objects.
 
+// A C/C++ data type.
 class DataType : public Symbol {
 	friend SourceFile;
 	friend SymbolList<DataType>;
@@ -343,6 +344,7 @@ public:
 	bool only_defined_in_single_translation_unit : 1 = false;
 };
 
+// A function. The type stored is the return type.
 class Function : public Symbol {
 	friend SourceFile;
 	friend SymbolList<Function>;
@@ -387,6 +389,7 @@ protected:
 	std::string m_mangled_name;
 };
 
+// A global variable.
 class GlobalVariable : public Symbol {
 	friend SourceFile;
 	friend SymbolList<GlobalVariable>;
@@ -409,6 +412,8 @@ protected:
 	std::string m_mangled_name;
 };
 
+// A label. This could be a label defined in assembly, C/C++, or just a symbol
+// for which we cannot automatically determine its type (e.g. SNDLL symbols).
 class Label : public Symbol {
 	friend SymbolList<Label>;
 public:
@@ -419,6 +424,8 @@ public:
 	LabelHandle handle() const { return m_handle; }
 };
 
+// A local variable. This includes static local variables which have global
+// storage.
 class LocalVariable : public Symbol {
 	friend Function;
 	friend SymbolList<LocalVariable>;
@@ -437,6 +444,11 @@ protected:
 	FunctionHandle m_function;
 };
 
+// A program module e.g. an ELF file or an SNDLL file. Every symbol has a module
+// field indicating what module the symbol belongs to. This can be used to
+// delete all the symbols associated with a given module. Additionally, when a
+// valid module pointer is passed to SymbolList<>::create_symbol, the address of
+// the symbol will be added to the address of the new symbol.
 class Module : public Symbol {
 public:
 	static constexpr const SymbolDescriptor DESCRIPTOR = SymbolDescriptor::MODULE;
@@ -463,6 +475,7 @@ protected:
 	FunctionHandle m_function;
 };
 
+// An ELF section. These are created from the ELF section headers.
 class Section : public Symbol {
 	friend SymbolList<Section>;
 public:
@@ -473,6 +486,8 @@ public:
 	SectionHandle handle() const { return m_handle; }
 };
 
+// A source file (.c or .cpp file). One of these will be created for every
+// translation unit in the program (but only if debugging symbols are present).
 class SourceFile : public Symbol {
 	friend SymbolList<SourceFile>;
 public:
@@ -499,6 +514,9 @@ protected:
 	GlobalVariableRange m_global_variables;
 };
 
+// A symbol source. Every symbol has a symbol source field indicating how the
+// symbol was created. For example, the symbol table importers will each create
+// one of these (if it doesn't already exist).
 class SymbolSource : public Symbol {
 	friend SymbolList<SymbolSource>;
 public:

--- a/src/ccc/symbol_file.cpp
+++ b/src/ccc/symbol_file.cpp
@@ -5,7 +5,7 @@
 
 namespace ccc {
 
-Result<std::unique_ptr<SymbolFile>> parse_symbol_file(std::vector<u8> image)
+Result<std::unique_ptr<SymbolFile>> parse_symbol_file(std::vector<u8> image, std::string file_name)
 {
 	const u32* magic = get_packed<u32>(image, 0);
 	CCC_CHECK(magic, "File too small.");
@@ -17,7 +17,7 @@ Result<std::unique_ptr<SymbolFile>> parse_symbol_file(std::vector<u8> image)
 			Result<ElfFile> elf = parse_elf_file(std::move(image));
 			CCC_RETURN_IF_ERROR(elf);
 			
-			symbol_file = std::make_unique<ElfSymbolFile>(std::move(*elf));
+			symbol_file = std::make_unique<ElfSymbolFile>(std::move(*elf), std::move(file_name));
 			break;
 		}
 		case CCC_FOURCC("SNR1"):
@@ -36,8 +36,13 @@ Result<std::unique_ptr<SymbolFile>> parse_symbol_file(std::vector<u8> image)
 	return symbol_file;
 }
 
-ElfSymbolFile::ElfSymbolFile(ElfFile elf)
-	: m_elf(std::move(elf)) {}
+ElfSymbolFile::ElfSymbolFile(ElfFile elf, std::string elf_name)
+	: m_elf(std::move(elf)), m_name(std::move(elf_name)) {}
+
+std::string ElfSymbolFile::name() const
+{
+	return m_name;
+}
 
 Result<std::vector<std::unique_ptr<SymbolTable>>> ElfSymbolFile::get_all_symbol_tables() const
 {
@@ -83,10 +88,15 @@ Result<std::vector<std::unique_ptr<SymbolTable>>> ElfSymbolFile::get_symbol_tabl
 SNDLLSymbolFile::SNDLLSymbolFile(SNDLLFile sndll)
 	: m_sndll(std::move(sndll)) {}
 
+std::string SNDLLSymbolFile::name() const
+{
+	return m_sndll.elf_path;
+}
+
 Result<std::vector<std::unique_ptr<SymbolTable>>> SNDLLSymbolFile::get_all_symbol_tables() const
 {
 	std::vector<std::unique_ptr<SymbolTable>> symbol_tables;
-	symbol_tables.emplace_back(std::make_unique<SNDLLSymbolTable>(std::make_shared<SNDLLFile>(std::move(m_sndll)), ""));
+	symbol_tables.emplace_back(std::make_unique<SNDLLSymbolTable>(std::make_shared<SNDLLFile>(std::move(m_sndll))));
 	return symbol_tables;
 }
 

--- a/src/ccc/symbol_file.cpp
+++ b/src/ccc/symbol_file.cpp
@@ -85,6 +85,11 @@ Result<std::vector<std::unique_ptr<SymbolTable>>> ElfSymbolFile::get_symbol_tabl
 	return symbol_tables;
 }
 
+const ElfFile& ElfSymbolFile::elf() const
+{
+	return m_elf;
+}
+
 SNDLLSymbolFile::SNDLLSymbolFile(SNDLLFile sndll)
 	: m_sndll(std::move(sndll)) {}
 

--- a/src/ccc/symbol_file.h
+++ b/src/ccc/symbol_file.h
@@ -18,28 +18,35 @@ class SymbolFile {
 public:
 	virtual ~SymbolFile() {}
 	
+	virtual std::string name() const = 0;
+	
 	virtual Result<std::vector<std::unique_ptr<SymbolTable>>> get_all_symbol_tables() const = 0;
 	virtual Result<std::vector<std::unique_ptr<SymbolTable>>> get_symbol_tables_from_sections(
 		const std::vector<SymbolTableLocation>& sections) const = 0;
 };
 
 // Determine the type of the input file and parse it.
-Result<std::unique_ptr<SymbolFile>> parse_symbol_file(std::vector<u8> image);
+Result<std::unique_ptr<SymbolFile>> parse_symbol_file(std::vector<u8> image, std::string file_name);
 
 class ElfSymbolFile : public SymbolFile {
 public:
-	ElfSymbolFile(ElfFile elf);
+	ElfSymbolFile(ElfFile elf, std::string elf_name);
+	
+	std::string name() const override;
 	
 	Result<std::vector<std::unique_ptr<SymbolTable>>> get_all_symbol_tables() const override;
 	Result<std::vector<std::unique_ptr<SymbolTable>>> get_symbol_tables_from_sections(
 		const std::vector<SymbolTableLocation>& sections) const override;
 	
 	ElfFile m_elf;
+	std::string m_name;
 };
 
 class SNDLLSymbolFile : public SymbolFile {
 public:
 	SNDLLSymbolFile(SNDLLFile sndll);
+	
+	std::string name() const override;
 	
 	Result<std::vector<std::unique_ptr<SymbolTable>>> get_all_symbol_tables() const override;
 	Result<std::vector<std::unique_ptr<SymbolTable>>> get_symbol_tables_from_sections(

--- a/src/ccc/symbol_file.h
+++ b/src/ccc/symbol_file.h
@@ -38,6 +38,9 @@ public:
 	Result<std::vector<std::unique_ptr<SymbolTable>>> get_symbol_tables_from_sections(
 		const std::vector<SymbolTableLocation>& sections) const override;
 	
+	const ElfFile& elf() const;
+	
+protected:
 	ElfFile m_elf;
 	std::string m_name;
 };

--- a/src/ccc/symbol_json.cpp
+++ b/src/ccc/symbol_json.cpp
@@ -22,6 +22,7 @@ static void write_json(JsonWriter& json, const Function& symbol, const SymbolDat
 static void write_json(JsonWriter& json, const GlobalVariable& symbol, const SymbolDatabase& database);
 static void write_json(JsonWriter& json, const Label& symbol, const SymbolDatabase& database);
 static void write_json(JsonWriter& json, const LocalVariable& symbol, const SymbolDatabase& database);
+static void write_json(JsonWriter& json, const Module& symbol, const SymbolDatabase& database);
 static void write_json(JsonWriter& json, const ParameterVariable& symbol, const SymbolDatabase& database);
 static void write_json(JsonWriter& json, const Section& symbol, const SymbolDatabase& database);
 static void write_json(JsonWriter& json, const SourceFile& symbol, const SymbolDatabase& database);
@@ -73,6 +74,11 @@ static void write_symbol_list(
 		if(symbol.size() != 0) {
 			json.Key("size");
 			json.Uint(symbol.size());
+		}
+		
+		if(symbol.module_handle().valid()) {
+			json.Key("module");
+			json.Uint(database.modules.index_from_handle(symbol.module_handle()));
 		}
 		
 		write_json(json, symbol, database);
@@ -229,6 +235,8 @@ static void write_json(JsonWriter& json, const LocalVariable& symbol, const Symb
 	}
 }
 
+static void write_json(JsonWriter& json, const Module& symbol, const SymbolDatabase& database) {}
+
 static void write_json(JsonWriter& json, const ParameterVariable& symbol, const SymbolDatabase& database)
 {
 	if(const RegisterStorage* storage = std::get_if<RegisterStorage>(&symbol.storage)) {
@@ -245,9 +253,7 @@ static void write_json(JsonWriter& json, const ParameterVariable& symbol, const 
 	}
 }
 
-static void write_json(JsonWriter& json, const Section& symbol, const SymbolDatabase& database)
-{
-}
+static void write_json(JsonWriter& json, const Section& symbol, const SymbolDatabase& database) {}
 
 static void write_json(JsonWriter& json, const SourceFile& symbol, const SymbolDatabase& database)
 {

--- a/src/ccc/symbol_json.cpp
+++ b/src/ccc/symbol_json.cpp
@@ -33,7 +33,7 @@ void write_json(JsonWriter& json, const SymbolDatabase& database, const std::set
 	json.StartObject();
 	
 	json.Key("version");
-	json.Int(9);
+	json.Int(10);
 	
 	#define CCC_X(SymbolType, symbol_list) \
 		if(!std::is_same_v<SymbolType, SymbolSource>) { \
@@ -265,11 +265,6 @@ static void write_json(JsonWriter& json, const SourceFile& symbol, const SymbolD
 	if(!symbol.command_line_path.empty()) {
 		json.Key("command_line_path");
 		json.String(symbol.command_line_path);
-	}
-	
-	if(symbol.text_address != 0) {
-		json.Key("text_address");
-		json.Uint(symbol.text_address.value);
 	}
 	
 	if(!symbol.toolchain_version_info.empty()) {

--- a/src/ccc/util.h
+++ b/src/ccc/util.h
@@ -235,9 +235,9 @@ struct Address {
 		}
 	}
 	
-	Address add_base_address(u32 base_address) const {
+	Address add_base_address(Address base_address) const {
 		if(valid()) {
-			return base_address + value;
+			return base_address.get_or_zero() + value;
 		} else {
 			return Address();
 		}

--- a/src/ccc/util.h
+++ b/src/ccc/util.h
@@ -235,6 +235,14 @@ struct Address {
 		}
 	}
 	
+	Address add_base_address(u32 base_address) const {
+		if(valid()) {
+			return base_address + value;
+		} else {
+			return Address();
+		}
+	}
+	
 	friend auto operator<=>(const Address& lhs, const Address& rhs) = default;
 };
 

--- a/src/objdump.cpp
+++ b/src/objdump.cpp
@@ -18,7 +18,7 @@ int main(int argc, char** argv)
 	Result<ElfFile> elf = parse_elf_file(std::move(*image));
 	CCC_EXIT_IF_ERROR(elf);
 	
-	std::vector<ElfFile*> elves{&(*elf)};
+	std::vector<const ElfFile*> elves{&(*elf)};
 	
 	const ElfSection* text = elf->lookup_section(".text");
 	CCC_CHECK_FATAL(text, "ELF contains no .text section!");

--- a/src/stdump.cpp
+++ b/src/stdump.cpp
@@ -382,7 +382,7 @@ static void print_sections(FILE* out, const Options& options)
 		fprintf(out, "%s:\n", section.name().c_str());
 		
 		for(const SourceFile& source_file : database.source_files) {
-			if(source_file.text_address.valid() && source_file.text_address >= section_start && source_file.text_address < section_end) {
+			if(source_file.address().valid() && source_file.address() >= section_start && source_file.address() < section_end) {
 				fprintf(out, "\t%s\n", source_file.full_path().c_str());
 			}
 		}

--- a/src/stdump.cpp
+++ b/src/stdump.cpp
@@ -320,7 +320,8 @@ static void print_symbols(FILE* out, const Options& options)
 	Result<std::vector<u8>> image = platform::read_binary_file(options.input_file);
 	CCC_EXIT_IF_ERROR(image);
 	
-	Result<std::unique_ptr<SymbolFile>> symbol_file = parse_symbol_file(std::move(*image));
+	Result<std::unique_ptr<SymbolFile>> symbol_file = parse_symbol_file(
+		std::move(*image), options.input_file.filename().string());
 	CCC_EXIT_IF_ERROR(symbol_file);
 	
 	std::vector<std::unique_ptr<SymbolTable>> symbol_tables = select_symbol_tables(**symbol_file, options.sections);
@@ -343,7 +344,8 @@ static void print_headers(FILE* out, const Options& options)
 	Result<std::vector<u8>> image = platform::read_binary_file(options.input_file);
 	CCC_EXIT_IF_ERROR(image);
 	
-	Result<std::unique_ptr<SymbolFile>> symbol_file = parse_symbol_file(std::move(*image));
+	Result<std::unique_ptr<SymbolFile>> symbol_file = parse_symbol_file(
+		std::move(*image), options.input_file.filename().string());
 	CCC_EXIT_IF_ERROR(symbol_file);
 	
 	std::vector<std::unique_ptr<SymbolTable>> symbol_tables = select_symbol_tables(**symbol_file, options.sections);
@@ -392,7 +394,8 @@ static SymbolDatabase read_symbol_table(std::unique_ptr<SymbolFile>& symbol_file
 	Result<std::vector<u8>> image = platform::read_binary_file(options.input_file);
 	CCC_EXIT_IF_ERROR(image);
 	
-	Result<std::unique_ptr<SymbolFile>> symbol_file_result = parse_symbol_file(std::move(*image));
+	Result<std::unique_ptr<SymbolFile>> symbol_file_result = parse_symbol_file(
+		std::move(*image), options.input_file.filename().string());
 	CCC_EXIT_IF_ERROR(symbol_file_result);
 	symbol_file = std::move(*symbol_file_result);
 	
@@ -404,8 +407,9 @@ static SymbolDatabase read_symbol_table(std::unique_ptr<SymbolFile>& symbol_file
 	demangler.cplus_demangle = cplus_demangle;
 	demangler.cplus_demangle_opname = cplus_demangle_opname;
 	
-	Result<SymbolSourceRange> symbol_sources = import_symbol_tables(database, symbol_tables, options.importer_flags, demangler);
-	CCC_EXIT_IF_ERROR(symbol_sources);
+	Result<ModuleHandle> module_handle = import_symbol_tables(
+		database, symbol_file->name(), symbol_tables, options.importer_flags, demangler);
+	CCC_EXIT_IF_ERROR(module_handle);
 	
 	return database;
 }

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -46,7 +46,7 @@ static int main_test(const fs::path& input_directory)
 			Result<std::vector<u8>> image = platform::read_binary_file(entry.path());
 			CCC_EXIT_IF_ERROR(image);
 			
-			Result<std::unique_ptr<SymbolFile>> symbol_file = parse_symbol_file(*image);
+			Result<std::unique_ptr<SymbolFile>> symbol_file = parse_symbol_file(*image, entry.path().filename().string());
 			if(symbol_file.success()) {
 				SymbolDatabase database;
 				
@@ -58,7 +58,7 @@ static int main_test(const fs::path& input_directory)
 				demangler.cplus_demangle_opname = cplus_demangle_opname;
 				
 				// Test the importers.
-				Result<SymbolSourceRange> handle = import_symbol_tables(database, *symbol_tables, STRICT_PARSING, demangler);
+				Result<ModuleHandle> handle = import_symbol_tables(database, (*symbol_file)->name(), *symbol_tables, STRICT_PARSING, demangler);
 				CCC_EXIT_IF_ERROR(handle);
 				
 				// Test the C++ printing code.

--- a/src/uncc.cpp
+++ b/src/uncc.cpp
@@ -65,7 +65,8 @@ int main(int argc, char** argv)
 	Result<ElfFile> elf_result = parse_elf_file(std::move(*image));
 	CCC_EXIT_IF_ERROR(elf_result);
 	
-	Result<std::unique_ptr<ElfSymbolFile>> symbol_file = std::make_unique<ElfSymbolFile>(std::move(*elf_result));
+	Result<std::unique_ptr<ElfSymbolFile>> symbol_file = std::make_unique<ElfSymbolFile>(
+		std::move(*elf_result), options.elf_path.filename().string());
 	CCC_EXIT_IF_ERROR(symbol_file);
 	
 	DemanglerFunctions demangler;
@@ -76,8 +77,9 @@ int main(int argc, char** argv)
 	CCC_EXIT_IF_ERROR(symbol_tables);
 	
 	SymbolDatabase database;
-	Result<SymbolSourceRange> symbol_source = import_symbol_tables(database, *symbol_tables, options.importer_flags, demangler);
-	CCC_EXIT_IF_ERROR(symbol_source);
+	Result<ModuleHandle> module_handle = import_symbol_tables(
+		database, (*symbol_file)->name(), *symbol_tables, options.importer_flags, demangler);
+	CCC_EXIT_IF_ERROR(module_handle);
 	
 	map_types_to_files_based_on_this_pointers(database);
 	map_types_to_files_based_on_reference_count(database);

--- a/src/uncc.cpp
+++ b/src/uncc.cpp
@@ -31,7 +31,7 @@ static void write_c_cpp_file(
 	const SymbolDatabase& database,
 	const std::vector<SourceFileHandle>& files,
 	const FunctionsFile& functions_file,
-	const std::vector<ElfFile*>& elves);
+	const std::vector<const ElfFile*>& elves);
 static void write_h_file(
 	const fs::path& path,
 	std::string relative_path,
@@ -84,7 +84,7 @@ int main(int argc, char** argv)
 	map_types_to_files_based_on_this_pointers(database);
 	map_types_to_files_based_on_reference_count(database);
 	
-	std::vector<ElfFile*> elves{&((*symbol_file)->m_elf)};
+	std::vector<const ElfFile*> elves{&((*symbol_file)->elf())};
 	
 	mdebug::fill_in_pointers_to_member_function_definitions(database);
 	
@@ -237,7 +237,7 @@ static void write_c_cpp_file(
 	const SymbolDatabase& database,
 	const std::vector<SourceFileHandle>& files,
 	const FunctionsFile& functions_file,
-	const std::vector<ElfFile*>& elves)
+	const std::vector<const ElfFile*>& elves)
 {
 	printf("Writing %s\n", path.string().c_str());
 	FILE* out = fopen(path.string().c_str(), "w");


### PR DESCRIPTION
This was motivated by the need to support IRX modules in PCSX2, but could also be used to support SNDLL and ERX files in the future.