### PR TITLE
Fix issue where absolute SNDLL symbols were being treated as relative

### DIFF
--- a/src/ccc/sndll.h
+++ b/src/ccc/sndll.h
@@ -28,6 +28,7 @@ struct SNDLLSymbol {
 
 struct SNDLLFile {
 	Address address;
+	bool symbols_relative;
 	SNDLLVersion version;
 	std::string elf_path;
 	std::vector<SNDLLSymbol> symbols;
@@ -35,7 +36,7 @@ struct SNDLLFile {
 
 // If a valid address is passed, the pointers in the header will be treated as
 // addresses, otherwise they will be treated as file offsets.
-Result<SNDLLFile> parse_sndll_file(std::span<const u8> image, Address address = Address());
+Result<SNDLLFile> parse_sndll_file(std::span<const u8> image, Address address, bool symbols_relative);
 
 Result<void> import_sndll_symbols(
 	SymbolDatabase& database,

--- a/src/ccc/symbol_file.cpp
+++ b/src/ccc/symbol_file.cpp
@@ -22,7 +22,7 @@ Result<std::unique_ptr<SymbolFile>> parse_symbol_file(std::vector<u8> image, std
 		}
 		case CCC_FOURCC("SNR1"):
 		case CCC_FOURCC("SNR2"): {
-			Result<SNDLLFile> sndll = parse_sndll_file(image);
+			Result<SNDLLFile> sndll = parse_sndll_file(image, Address(), true);
 			CCC_RETURN_IF_ERROR(sndll);
 			
 			symbol_file = std::make_unique<SNDLLSymbolFile>(std::move(*sndll));

--- a/src/ccc/symbol_table.cpp
+++ b/src/ccc/symbol_table.cpp
@@ -81,7 +81,7 @@ Result<std::unique_ptr<SymbolTable>> create_elf_symbol_table(
 			std::span<const u8> data = std::span(elf.image).subspan(section.offset, section.size);
 			
 			if(data.size() >= 4 && data[0] != '\0') {
-				Result<SNDLLFile> file = parse_sndll_file(data, section.address);
+				Result<SNDLLFile> file = parse_sndll_file(data, section.address, false);
 				CCC_RETURN_IF_ERROR(file);
 				
 				symbol_table = std::make_unique<SNDLLSymbolTable>(std::make_shared<SNDLLFile>(std::move(*file)));


### PR DESCRIPTION
This resulted in the addresses for these symbols being way too big.