### PR TITLE
Use lists of handles to represent relationships between symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Use of a code formatter such as `clang-format` or `astyle` on the output is reco
 
 | Format Version | Release | Changes |
 | - | - | - |
+| 11 | | Lists of indices (instead of begin and end indices) are now used for relationships between symbols. |
 | 10 | | Added modules as their own symbol type. Removed the text_address property of source file symbols. |
 | 9 | | Added optional is_virtual_base_class property to nodes in base class lists. |
 | 8 | | Overhauled the format based on the structure of the new symbol database. An error AST node type has been added. The data, function definition, initializer list, source file and variable AST node types have been removed and replaced. |

--- a/src/ccc/mdebug_analysis.h
+++ b/src/ccc/mdebug_analysis.h
@@ -83,11 +83,11 @@ protected:
 	
 	AnalysisState m_state = NOT_IN_FUNCTION;
 	SourceFile& m_source_file;
-	FunctionRange m_functions;
-	GlobalVariableRange m_global_variables;
+	std::vector<FunctionHandle> m_functions;
+	std::vector<GlobalVariableHandle> m_global_variables;
 	Function* m_current_function = nullptr;
-	ParameterVariableRange m_current_parameter_variables;
-	LocalVariableRange m_current_local_variables;
+	std::vector<ParameterVariableHandle> m_current_parameter_variables;
+	std::vector<LocalVariableHandle> m_current_local_variables;
 	std::vector<std::vector<LocalVariableHandle>> m_blocks;
 	std::vector<LocalVariableHandle> m_pending_local_variables;
 	std::string m_next_relative_path;

--- a/src/ccc/print_cpp.h
+++ b/src/ccc/print_cpp.h
@@ -56,7 +56,7 @@ protected:
 		s32 indentation_level,
 		const SymbolDatabase& database,
 		bool print_body = true);
-	void function_parameters(std::span<const ParameterVariable> parameters, const SymbolDatabase& database);
+	void function_parameters(std::vector<const ParameterVariable*> parameters, const SymbolDatabase& database);
 	void refined_data(const RefinedData& data, s32 indentation_level);
 	void global_storage_comment(const GlobalStorage& storage, Address address);
 	void register_storage_comment(const RegisterStorage& storage);

--- a/src/ccc/symbol_database.cpp
+++ b/src/ccc/symbol_database.cpp
@@ -30,6 +30,56 @@ const SymbolType* SymbolList<SymbolType>::symbol_from_handle(SymbolHandle<Symbol
 }
 
 template <typename SymbolType>
+std::vector<SymbolType*> SymbolList<SymbolType>::symbols_from_handles(
+	const std::vector<SymbolHandle<SymbolType>>& handles)
+{
+	std::vector<SymbolType*> result;
+	for(SymbolHandle<SymbolType> handle : handles) {
+		SymbolType* symbol = symbol_from_handle(handle);
+		if(symbol) {
+			result.emplace_back(symbol);
+		}
+	}
+	return result;
+}
+
+template <typename SymbolType>
+std::vector<const SymbolType*> SymbolList<SymbolType>::symbols_from_handles(
+	const std::vector<SymbolHandle<SymbolType>>& handles) const
+{
+	std::vector<const SymbolType*> result;
+	for(SymbolHandle<SymbolType> handle : handles) {
+		const SymbolType* symbol = symbol_from_handle(handle);
+		if(symbol) {
+			result.emplace_back(symbol);
+		}
+	}
+	return result;
+}
+
+template <typename SymbolType>
+std::vector<SymbolType*> SymbolList<SymbolType>::optional_symbols_from_handles(
+	const std::optional<std::vector<SymbolHandle<SymbolType>>>& handles)
+{
+	if(handles.has_value()) {
+		return symbols_from_handles(*handles);
+	} else {
+		return std::vector<SymbolType*>();
+	}
+}
+
+template <typename SymbolType>
+std::vector<const SymbolType*> SymbolList<SymbolType>::optional_symbols_from_handles(
+	const std::optional<std::vector<SymbolHandle<SymbolType>>>& handles) const
+{
+	if(handles.has_value()) {
+		return symbols_from_handles(*handles);
+	} else {
+		return std::vector<const SymbolType*>();
+	}
+}
+
+template <typename SymbolType>
 typename SymbolList<SymbolType>::Iterator SymbolList<SymbolType>::begin()
 {
 	return m_symbols.begin();
@@ -51,44 +101,6 @@ template <typename SymbolType>
 typename SymbolList<SymbolType>::ConstIterator SymbolList<SymbolType>::end() const
 {
 	return m_symbols.end();
-}
-
-template <typename SymbolType>
-std::span<SymbolType> SymbolList<SymbolType>::span(SymbolRange<SymbolType> range)
-{
-	size_t first = binary_search(range.first);
-	size_t last = binary_search(range.last);
-	if(last < m_symbols.size() && m_symbols[last].m_handle == range.last) {
-		return std::span<SymbolType>(m_symbols.data() + first, m_symbols.data() + last + 1);
-	} else {
-		return std::span<SymbolType>(m_symbols.data() + first, m_symbols.data() + last);
-	}
-}
-
-template <typename SymbolType>
-std::span<const SymbolType> SymbolList<SymbolType>::span(SymbolRange<SymbolType> range) const
-{
-	return const_cast<SymbolList<SymbolType>*>(this)->span(range);
-}
-
-template <typename SymbolType>
-std::span<SymbolType> SymbolList<SymbolType>::optional_span(std::optional<SymbolRange<SymbolType>> range)
-{
-	if(range.has_value()) {
-		return span(*range);
-	} else {
-		return std::span<SymbolType>();
-	}
-}
-
-template <typename SymbolType>
-std::span<const SymbolType> SymbolList<SymbolType>::optional_span(std::optional<SymbolRange<SymbolType>> range) const
-{
-	if(range.has_value()) {
-		return span(*range);
-	} else {
-		return std::span<SymbolType>();
-	}
 }
 
 template <typename SymbolType>
@@ -172,18 +184,6 @@ s32 SymbolList<SymbolType>::index_from_handle(SymbolHandle<SymbolType> handle) c
 	}
 	
 	return (s32) index;
-}
-
-template <typename SymbolType>
-std::pair<s32, s32> SymbolList<SymbolType>::index_pair_from_range(SymbolRange<SymbolType> range) const
-{
-	size_t first = binary_search(range.first);
-	size_t last = binary_search(range.last);
-	if(last < m_symbols.size() && m_symbols[last].m_handle == range.last) {
-		return {first, last + 1};
-	} else {
-		return {first, last};
-	}
 }
 
 template <typename SymbolType>
@@ -516,32 +516,62 @@ const char* global_storage_location_to_string(GlobalStorageLocation location)
 
 // *****************************************************************************
 
-void Function::set_parameter_variables(
-	std::optional<ParameterVariableRange> range, ShouldDeleteOldSymbols delete_old_symbols, SymbolDatabase& database)
+const std::optional<std::vector<ParameterVariableHandle>>& Function::parameter_variables() const
 {
-	if(delete_old_symbols == DELETE_OLD_SYMBOLS && m_parameter_variables.has_value()) {
-		database.parameter_variables.destroy_symbols(*m_parameter_variables);
-	}
-	if(range.has_value()) {
-		for(ParameterVariable& parameter_variable : database.parameter_variables.span(*range)) {
-			parameter_variable.m_function = m_handle;
+	return m_parameter_variables;
+}
+
+void Function::set_parameter_variables(
+	std::optional<std::vector<ParameterVariableHandle>> parameter_variables, SymbolDatabase& database)
+{
+	if(m_parameter_variables.has_value()) {
+		for(ParameterVariableHandle parameter_variable_handle : *m_parameter_variables) {
+			ParameterVariable* parameter_variable = database.parameter_variables.symbol_from_handle(parameter_variable_handle);
+			if(parameter_variable && parameter_variable->m_function == handle()) {
+				parameter_variable->m_function = FunctionHandle();
+			}
 		}
 	}
-	m_parameter_variables = range;
+	
+	m_parameter_variables = std::move(parameter_variables);
+	
+	if(m_parameter_variables.has_value()) {
+		for(ParameterVariableHandle parameter_variable_handle : *m_parameter_variables) {
+			ParameterVariable* parameter_variable = database.parameter_variables.symbol_from_handle(parameter_variable_handle);
+			if(parameter_variable) {
+				parameter_variable->m_function = handle();
+			}
+		}
+	}
+}
+	
+const std::optional<std::vector<LocalVariableHandle>>& Function::local_variables() const
+{
+	return m_local_variables;
 }
 
 void Function::set_local_variables(
-	std::optional<LocalVariableRange> range, ShouldDeleteOldSymbols delete_old_symbols, SymbolDatabase& database)
+	std::optional<std::vector<LocalVariableHandle>> local_variables, SymbolDatabase& database)
 {
-	if(delete_old_symbols == DELETE_OLD_SYMBOLS && m_local_variables.has_value()) {
-		database.local_variables.destroy_symbols(*m_local_variables);
-	}
-	if(range.has_value()) {
-		for(LocalVariable& local_variable : database.local_variables.span(*range)) {
-			local_variable.m_function = m_handle;
+	if(m_local_variables.has_value()) {
+		for(LocalVariableHandle local_variable_handle : *m_local_variables) {
+			LocalVariable* local_variable = database.local_variables.symbol_from_handle(local_variable_handle);
+			if(local_variable && local_variable->m_function == handle()) {
+				local_variable->m_function = FunctionHandle();
+			}
 		}
 	}
-	m_local_variables = range;
+	
+	m_local_variables = std::move(local_variables);
+	
+	if(m_local_variables.has_value()) {
+		for(LocalVariableHandle local_variable_handle : *m_local_variables) {
+			LocalVariable* local_variable = database.local_variables.symbol_from_handle(local_variable_handle);
+			if(local_variable) {
+				local_variable->m_function = handle();
+			}
+		}
+	}
 }
 
 const std::string& Function::mangled_name() const
@@ -572,27 +602,51 @@ void GlobalVariable::set_mangled_name(std::string mangled)
 	m_mangled_name = std::move(mangled);
 }
 
-void SourceFile::set_functions(
-	FunctionRange range, ShouldDeleteOldSymbols delete_old_symbols, SymbolDatabase& database)
+const std::vector<FunctionHandle>& SourceFile::functions() const
 {
-	if(delete_old_symbols == DELETE_OLD_SYMBOLS) {
-		database.functions.destroy_symbols(m_functions);
+	return m_functions;
+}
+
+void SourceFile::set_functions(std::vector<FunctionHandle> functions, SymbolDatabase& database)
+{
+	for(FunctionHandle function_handle : m_functions) {
+		Function* function = database.functions.symbol_from_handle(function_handle);
+		if(function && function->m_source_file == handle()) {
+			function->m_source_file = SourceFileHandle();
+		}
 	}
-	m_functions = range;
-	for(Function& function : database.functions.span(range)) {
-		function.m_source_file = m_handle;
+	
+	m_functions = std::move(functions);
+	
+	for(FunctionHandle function_handle : m_functions) {
+		Function* function = database.functions.symbol_from_handle(function_handle);
+		if(function) {
+			function->m_source_file = handle();
+		}
 	}
 }
 
-void SourceFile::set_global_variables(
-	GlobalVariableRange range, ShouldDeleteOldSymbols delete_old_symbols, SymbolDatabase& database)
+const std::vector<GlobalVariableHandle>& SourceFile::global_variables() const
 {
-	if(delete_old_symbols == DELETE_OLD_SYMBOLS) {
-		database.global_variables.destroy_symbols(m_global_variables);
+	return m_global_variables;
+}
+
+void SourceFile::set_global_variables(std::vector<GlobalVariableHandle> global_variables, SymbolDatabase& database)
+{
+	for(GlobalVariableHandle global_variable_handle : m_global_variables) {
+		GlobalVariable* global_variable = database.global_variables.symbol_from_handle(global_variable_handle);
+		if(global_variable && global_variable->m_source_file == handle()) {
+			global_variable->m_source_file = SourceFileHandle();
+		}
 	}
-	m_global_variables = range;
-	for(GlobalVariable& global_variable : database.global_variables.span(range)) {
-		global_variable.m_source_file = m_handle;
+	
+	m_global_variables = std::move(global_variables);
+	
+	for(GlobalVariableHandle global_variable_handle : m_global_variables) {
+		GlobalVariable* global_variable = database.global_variables.symbol_from_handle(global_variable_handle);
+		if(global_variable) {
+			global_variable->m_source_file = handle();
+		}
 	}
 }
 
@@ -758,10 +812,14 @@ bool SymbolDatabase::destroy_function(FunctionHandle handle)
 		return false;
 	}
 	if(function->parameter_variables().has_value()) {
-		parameter_variables.destroy_symbols(*function->parameter_variables());
+		for(ParameterVariableHandle parameter_variable_handle : *function->parameter_variables()) {
+			parameter_variables.destroy_symbol(parameter_variable_handle);
+		}
 	}
 	if(function->local_variables().has_value()) {
-		local_variables.destroy_symbols(*function->local_variables());
+		for(LocalVariableHandle local_variable_handle : *function->local_variables()) {
+			local_variables.destroy_symbol(local_variable_handle);
+		}
 	}
 	return functions.destroy_symbol(handle);
 }

--- a/src/ccc/symbol_json.h
+++ b/src/ccc/symbol_json.h
@@ -8,6 +8,8 @@
 
 namespace ccc {
 
+extern const u32 JSON_FORMAT_VERSION;
+
 void write_json(JsonWriter& json, const SymbolDatabase& database, const std::set<SymbolSourceHandle>* sources = nullptr);
 
 }

--- a/src/uncc.cpp
+++ b/src/uncc.cpp
@@ -273,9 +273,10 @@ static void write_c_cpp_file(
 	for(SourceFileHandle file_handle : files) {
 		const SourceFile* source_file = database.source_files.symbol_from_handle(file_handle);
 		CCC_ASSERT(source_file);
-		GlobalVariableRange global_variables = source_file->global_variables();
-		for(const GlobalVariable& global_variable : database.global_variables.span(global_variables)) {
-			printer.global_variable(global_variable, database, &read_virtual_func);
+		
+		const std::vector<GlobalVariableHandle>& global_variables = source_file->global_variables();
+		for(const GlobalVariable* global_variable : database.global_variables.symbols_from_handles(global_variables)) {
+			printer.global_variable(*global_variable, database, &read_virtual_func);
 		}
 	}
 	
@@ -283,9 +284,10 @@ static void write_c_cpp_file(
 	for(SourceFileHandle file_handle : files) {
 		const SourceFile* source_file = database.source_files.symbol_from_handle(file_handle);
 		CCC_ASSERT(source_file);
-		FunctionRange functions = source_file->functions();
-		for(const Function& function : database.functions.span(functions)) {
-			printer.function(function, database, &read_virtual_func);
+		
+		const std::vector<FunctionHandle>& functions = source_file->functions();
+		for(const Function* function : database.functions.symbols_from_handles(functions)) {
+			printer.function(*function, database, &read_virtual_func);
 		}
 	}
 	
@@ -336,12 +338,14 @@ static void write_h_file(
 	for(SourceFileHandle file_handle : files) {
 		const SourceFile* source_file = database.source_files.symbol_from_handle(file_handle);
 		CCC_ASSERT(source_file);
-		GlobalVariableRange global_variables = source_file->global_variables();
-		for(const GlobalVariable& global_variable : database.global_variables.span(global_variables)) {
-			printer.global_variable(global_variable, database, nullptr);
+		
+		const std::vector<GlobalVariableHandle>& global_variables = source_file->global_variables();
+		for(const GlobalVariable* global_variable : database.global_variables.symbols_from_handles(global_variables)) {
+			printer.global_variable(*global_variable, database, nullptr);
 			has_global = true;
 		}
 	}
+	
 	if(has_global) {
 		fprintf(out, "\n");
 	}
@@ -350,9 +354,10 @@ static void write_h_file(
 	for(SourceFileHandle file_handle : files) {
 		const SourceFile* source_file = database.source_files.symbol_from_handle(file_handle);
 		CCC_ASSERT(source_file);
-		FunctionRange functions = source_file->functions();
-		for(const Function& function : database.functions.span(functions)) {
-			printer.function(function, database, nullptr);
+		
+		const std::vector<FunctionHandle>& functions = source_file->functions();
+		for(const Function* function : database.functions.symbols_from_handles(functions)) {
+			printer.function(*function, database, nullptr);
 		}
 	}
 	
@@ -374,12 +379,15 @@ static bool needs_lost_and_found_file(const SymbolDatabase& database)
 static void write_lost_and_found_file(const fs::path& path, const SymbolDatabase& database)
 {
 	printf("Writing %s\n", path.string().c_str());
+	
 	FILE* out = fopen(path.string().c_str(), "w");
+	
 	CppPrinterConfig config;
 	config.print_offsets_and_sizes = false;
 	config.omit_this_parameter = true;
 	config.substitute_parameter_lists = true;
 	CppPrinter printer(out, config);
+	
 	s32 nodes_printed = 0;
 	for(const DataType& data_type : database.data_types) {
 		if(data_type.files.size() != 1) {
@@ -388,7 +396,9 @@ static void write_lost_and_found_file(const fs::path& path, const SymbolDatabase
 			}
 		}
 	}
+	
 	printf("%d types printed to lost and found file\n", nodes_printed);
+	
 	fclose(out);
 }
 


### PR DESCRIPTION
This replaces the use of handle ranges (i.e. begin and end handles) which made it so the symbols had to be contiguous, and didn't even save much memory.