### PR TITLE
Fix MultiSymbolHandle::destroy_symbol function

### DIFF
--- a/src/ccc/symbol_database.cpp
+++ b/src/ccc/symbol_database.cpp
@@ -1075,13 +1075,13 @@ bool MultiSymbolHandle::rename_symbol(std::string new_name, SymbolDatabase& data
 	return false;
 }
 
-bool MultiSymbolHandle::destroy_symbol(SymbolDatabase* database) const
+bool MultiSymbolHandle::destroy_symbol(SymbolDatabase& database, bool destroy_descendants) const
 {
 	if(m_handle != (u32) -1) {
 		switch(m_descriptor) {
 			#define CCC_X(SymbolType, symbol_list) \
 				case SymbolType::DESCRIPTOR: \
-					return database->symbol_list.destroy_symbol(m_handle, database);
+					return database.symbol_list.destroy_symbol(m_handle, destroy_descendants ? &database : nullptr);
 			CCC_FOR_EACH_SYMBOL_TYPE_DO_X
 			#undef CCC_X
 		}

--- a/src/ccc/symbol_database.h
+++ b/src/ccc/symbol_database.h
@@ -663,7 +663,7 @@ public:
 	bool is_flag_set(SymbolFlag flag) const;
 	bool move_symbol(Address new_address, SymbolDatabase& database) const;
 	bool rename_symbol(std::string new_name, SymbolDatabase& database) const;
-	bool destroy_symbol(SymbolDatabase* database) const;
+	bool destroy_symbol(SymbolDatabase& database, bool destroy_descendants) const;
 	
 	friend auto operator<=>(const MultiSymbolHandle& lhs, const MultiSymbolHandle& rhs) = default;
 	


### PR DESCRIPTION
Previously it was not possible to specify that you didn't want to destroy descendant symbols.