### PR TITLE
Read the text address for source files from the file descriptor

### DIFF
--- a/src/ccc/mdebug_importer.cpp
+++ b/src/ccc/mdebug_importer.cpp
@@ -126,17 +126,8 @@ Result<void> import_file(SymbolDatabase& database, const mdebug::File& input, co
 		}
 	}
 	
-	// Find the address of the source file.
-	Address text_address;
-	for(const ParsedSymbol& symbol : *symbols) {
-		if(symbol.type == ParsedSymbolType::SOURCE_FILE) {
-			text_address = symbol.raw->value;
-			break;
-		}
-	}
-	
 	Result<SourceFile*> source_file = database.source_files.create_symbol(
-		input.full_path, text_address, context.group.source, context.module_symbol);
+		input.full_path, input.address, context.group.source, context.module_symbol);
 	CCC_RETURN_IF_ERROR(source_file);
 	
 	(*source_file)->working_dir = input.working_dir;

--- a/src/ccc/mdebug_section.cpp
+++ b/src/ccc/mdebug_section.cpp
@@ -137,6 +137,8 @@ Result<File> SymbolTableReader::parse_file(s32 index) const
 	CCC_CHECK(fd_header != nullptr, "MIPS debug file descriptor out of bounds.");
 	CCC_CHECK(fd_header->f_big_endian == 0, "Not little endian or bad file descriptor table.");
 	
+	file.address = fd_header->address;
+	
 	s32 raw_path_offset = m_hdrr->local_strings_offset + fd_header->strings_offset + fd_header->file_path_string_offset + m_fudge_offset;
 	const char* command_line_path = get_string(m_elf, raw_path_offset);
 	if(command_line_path) {

--- a/src/ccc/mdebug_section.h
+++ b/src/ccc/mdebug_section.h
@@ -120,8 +120,9 @@ struct Symbol {
 
 struct File {
 	std::vector<Symbol> symbols;
-	std::string working_dir; // The working directory of GCC.
-	std::string command_line_path; // The source file path passed on the command line to GCC.
+	u32 address = 0;
+	std::string working_dir; // The working directory of gcc.
+	std::string command_line_path; // The source file path passed on the command line to gcc.
 	std::string full_path; // The full combined path.
 };
 


### PR DESCRIPTION
This is more reliable than scanning for a symbol.