### PR TITLE
Make CCC_ASSERT call abort and rename some other error handling macros

### DIFF
--- a/src/ccc/util.h
+++ b/src/ccc/util.h
@@ -57,22 +57,29 @@ void report_error(const Error& error);
 void report_warning(const Error& warning);
 void set_custom_error_callback(CustomErrorCallback callback);
 
-#define CCC_FATAL(...) \
+#define CCC_EXIT(...) \
 	{ \
 		ccc::Error error = ccc::format_error(__FILE__, __LINE__, __VA_ARGS__); \
 		ccc::report_error(error); \
 		exit(1); \
 	}
-	
-#define CCC_CHECK_FATAL(condition, ...) \
+
+#define CCC_EXIT_IF_FALSE(condition, ...) \
 	if(!(condition)) { \
 		ccc::Error error = ccc::format_error(__FILE__, __LINE__, __VA_ARGS__); \
 		ccc::report_error(error); \
 		exit(1); \
 	}
 
+#define CCC_ABORT_IF_FALSE(condition, ...) \
+	if(!(condition)) { \
+		ccc::Error error = ccc::format_error(__FILE__, __LINE__, __VA_ARGS__); \
+		ccc::report_error(error); \
+		abort(); \
+	}
+
 #define CCC_ASSERT(condition) \
-	CCC_CHECK_FATAL(condition, #condition)
+	CCC_ABORT_IF_FALSE(condition, #condition)
 
 // The main error handling construct in CCC. This class is used to bundle
 // together a return value and a pointer to error information, so that errors

--- a/src/demangle.cpp
+++ b/src/demangle.cpp
@@ -13,7 +13,7 @@ int main(int argc, char** argv)
 {
 	if(argc == 2 && !(strcmp(argv[1], "help") == 0 || strcmp(argv[1], "--help") == 0 || strcmp(argv[1], "-h") == 0)) {
 		const char* demangled = cplus_demangle(argv[1], DMGL_PARAMS | DMGL_RET_POSTFIX);
-		CCC_CHECK_FATAL(demangled, "Cannot demangle input!");
+		CCC_EXIT_IF_FALSE(demangled, "Cannot demangle input!");
 		printf("%s", demangled);
 		return 0;
 	} else {

--- a/src/mips/insn.cpp
+++ b/src/mips/insn.cpp
@@ -81,7 +81,7 @@ const InsnInfo& Insn::info() const
 		case INSN_CLASS_COP1_S: return COP1_S_TABLE[func()];
 		case INSN_CLASS_COP1_W: return COP1_W_TABLE[func()];
 		case INSN_CLASS_COP2: return MIPS_OPCODE_TABLE[OPCODE_COP2];
-		default: CCC_FATAL("Invalid instruction %08x.", value);
+		default: CCC_EXIT("Invalid instruction %08x.", value);
 	}
 }
 

--- a/src/objdump.cpp
+++ b/src/objdump.cpp
@@ -9,7 +9,7 @@ using namespace ccc;
 
 int main(int argc, char** argv)
 {
-	CCC_CHECK_FATAL(argc == 2, "Incorrect number of arguments.");
+	CCC_EXIT_IF_FALSE(argc == 2, "Incorrect number of arguments.");
 	
 	fs::path input_path(argv[1]);
 	Result<std::vector<u8>> image = platform::read_binary_file(input_path);
@@ -19,10 +19,10 @@ int main(int argc, char** argv)
 	CCC_EXIT_IF_ERROR(elf);
 	
 	const ElfSection* text = elf->lookup_section(".text");
-	CCC_CHECK_FATAL(text, "ELF contains no .text section!");
+	CCC_EXIT_IF_FALSE(text, "ELF contains no .text section!");
 	
 	std::optional<u32> text_address = elf->file_offset_to_virtual_address(text->header.offset);
-	CCC_CHECK_FATAL(text_address.has_value(), "Failed to translate file offset to virtual address.");
+	CCC_EXIT_IF_FALSE(text_address.has_value(), "Failed to translate file offset to virtual address.");
 	
 	Result<std::span<const mips::Insn>> insns = elf->get_array_virtual<mips::Insn>(*text_address, text->header.size / 4);
 	CCC_EXIT_IF_ERROR(insns);

--- a/src/stdump.cpp
+++ b/src/stdump.cpp
@@ -112,7 +112,7 @@ int main(int argc, char** argv)
 	FILE* out = stdout;
 	if(!options.output_file.empty()) {
 		out = fopen(options.output_file.string().c_str(), "w");
-		CCC_CHECK_FATAL(out, "Failed to open output file '%s'.", options.output_file.string().c_str());
+		CCC_EXIT_IF_FALSE(out, "Failed to open output file '%s'.", options.output_file.string().c_str());
 	}
 	
 	if(options.function) {
@@ -144,7 +144,7 @@ static void identify_symbol_tables(FILE* out, const Options& options)
 		}
 		fprintf(out, "  %4d unknown\n", unknown_total);
 	} else {
-		CCC_FATAL("Input path '%s' is neither a regular file nor a directory.", options.input_file.string().c_str());
+		CCC_EXIT("Input path '%s' is neither a regular file nor a directory.", options.input_file.string().c_str());
 	}
 }
 
@@ -559,7 +559,7 @@ static Options parse_command_line_arguments(int argc, char** argv)
 			if(i + 1 < argc) {
 				options.output_file = argv[++i];
 			} else {
-				CCC_FATAL("No output path specified.");
+				CCC_EXIT("No output path specified.");
 			}
 		} else if(strcmp(arg, "--section") == 0) {
 			if(i + 2 < argc) {
@@ -567,21 +567,21 @@ static Options parse_command_line_arguments(int argc, char** argv)
 				section.section_name = argv[++i];
 				section.format = symbol_table_format_from_name(argv[++i])->format;
 			} else if(i + 1 < argc) {
-				CCC_FATAL("Missing format after --section.");
+				CCC_EXIT("Missing format after --section.");
 			} else {
-				CCC_FATAL("Missing section name after --section.");
+				CCC_EXIT("Missing section name after --section.");
 			}
 		} else if(strncmp(arg, "--", 2) == 0) {
-			CCC_FATAL("Unknown option '%s'.", arg);
+			CCC_EXIT("Unknown option '%s'.", arg);
 		} else if(input_path_provided) {
-			CCC_FATAL("Multiple input paths specified.");
+			CCC_EXIT("Multiple input paths specified.");
 		} else {
 			options.input_file = argv[i];
 			input_path_provided = true;
 		}
 	}
 	
-	CCC_CHECK_FATAL(!require_input_path || !options.input_file.empty(), "No input path specified.");
+	CCC_EXIT_IF_FALSE(!require_input_path || !options.input_file.empty(), "No input path specified.");
 	
 	return options;
 }

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -36,7 +36,7 @@ int main(int argc, char** argv)
 
 static int main_test(const fs::path& input_directory)
 {
-	CCC_CHECK_FATAL(fs::is_directory(input_directory), "Input path is not a directory.");
+	CCC_EXIT_IF_FALSE(fs::is_directory(input_directory), "Input path is not a directory.");
 	
 	for(auto entry : fs::recursive_directory_iterator(input_directory)) {
 		if(entry.is_regular_file()) {

--- a/src/uncc.cpp
+++ b/src/uncc.cpp
@@ -49,7 +49,7 @@ int main(int argc, char** argv)
 		return 1;
 	}
 	
-	CCC_CHECK_FATAL(fs::is_directory(options.output_path), "Output path needs to be a directory!");
+	CCC_EXIT_IF_FALSE(fs::is_directory(options.output_path), "Output path needs to be a directory!");
 	fs::path sources_file_path = options.output_path/"SOURCES.txt";
 	fs::path functions_file_path = options.output_path/"FUNCTIONS.txt";
 	
@@ -138,7 +138,7 @@ int main(int argc, char** argv)
 static std::vector<std::string> parse_sources_file(const fs::path& path)
 {
 	std::optional<std::string> file = platform::read_text_file(path);
-	CCC_CHECK_FATAL(file.has_value(), "Failed to open file '%s'", path.string().c_str());
+	CCC_EXIT_IF_FALSE(file.has_value(), "Failed to open file '%s'", path.string().c_str());
 	std::string_view input(*file);
 	std::vector<std::string> sources;
 	while(skip_whitespace(input), input.size() > 0) {
@@ -152,7 +152,7 @@ static FunctionsFile parse_functions_file(const fs::path& path)
 	FunctionsFile result;
 	
 	std::optional<std::string> file = platform::read_text_file(path);
-	CCC_CHECK_FATAL(file.has_value(), "Failed to open file '%s'", path.string().c_str());
+	CCC_EXIT_IF_FALSE(file.has_value(), "Failed to open file '%s'", path.string().c_str());
 	result.contents = std::move(*file);
 	
 	// Parse the file.
@@ -160,10 +160,10 @@ static FunctionsFile parse_functions_file(const fs::path& path)
 	std::span<char>* function = nullptr;
 	for(std::span<char> line = eat_line(input); line.data() != nullptr; line = eat_line(input)) {
 		if(line.size() >= 9 && memcmp(line.data(), "@function", 9) == 0) {
-			CCC_CHECK_FATAL(line.size() > 10, "Bad @function directive in FUNCTIONS.txt file.");
+			CCC_EXIT_IF_FALSE(line.size() > 10, "Bad @function directive in FUNCTIONS.txt file.");
 			char* end = nullptr;
 			u32 address = (u32) strtol(line.data() + 10, &end, 16);
-			CCC_CHECK_FATAL(end != line.data() + 10, "Bad @function directive in FUNCTIONS.txt file.");
+			CCC_EXIT_IF_FALSE(end != line.data() + 10, "Bad @function directive in FUNCTIONS.txt file.");
 			function = &result.functions[address];
 			*function = input.subspan(1);
 		} else if(function) {
@@ -239,7 +239,7 @@ static void write_c_cpp_file(
 {
 	printf("Writing %s\n", path.string().c_str());
 	FILE* out = fopen(path.string().c_str(), "w");
-	CCC_CHECK_FATAL(out, "Failed to open '%s' for writing.", path.string().c_str());
+	CCC_EXIT_IF_FALSE(out, "Failed to open '%s' for writing.", path.string().c_str());
 	fprintf(out, "// STATUS: NOT STARTED\n\n");
 	
 	// Configure printing.
@@ -414,7 +414,7 @@ static Options parse_command_line_arguments(int argc, char** argv)
 			options.output_path = argv[i];
 			positional++;
 		} else {
-			CCC_FATAL("Too many arguments.");
+			CCC_EXIT("Too many arguments.");
 		}
 	}
 	


### PR DESCRIPTION
This will make assertion failures less messy when CCC is running inside PCSX2.