### PR TITLE
Add mangled name maps for functions and global variables

### DIFF
--- a/src/ccc/mdebug_analysis.cpp
+++ b/src/ccc/mdebug_analysis.cpp
@@ -106,7 +106,7 @@ Result<void> LocalSymbolTableAnalyser::sub_source_file(const char* path, Address
 Result<void> LocalSymbolTableAnalyser::procedure(
 	const char* mangled_name, Address address, const ProcedureDescriptor* procedure_descriptor, bool is_static)
 {
-	if (!m_current_function || strcmp(mangled_name, m_current_function->mangled_name().c_str()) != 0) {
+	if (!m_current_function || strcmp(mangled_name, m_current_function->raw_name().c_str()) != 0) {
 		Result<void> result = create_function(mangled_name, address);
 		CCC_RETURN_IF_ERROR(result);
 	}
@@ -146,7 +146,7 @@ Result<void> LocalSymbolTableAnalyser::text_end(const char* name, s32 function_s
 
 Result<void> LocalSymbolTableAnalyser::function(const char* mangled_name, const StabsType& return_type, Address address)
 {
-	if (!m_current_function || strcmp(mangled_name, m_current_function->mangled_name().c_str()) != 0) {
+	if (!m_current_function || strcmp(mangled_name, m_current_function->raw_name().c_str()) != 0) {
 		Result<void> result = create_function(mangled_name, address);
 		CCC_RETURN_IF_ERROR(result);
 	} else {

--- a/src/ccc/mdebug_importer.cpp
+++ b/src/ccc/mdebug_importer.cpp
@@ -543,7 +543,7 @@ static void detect_duplicate_functions(SymbolDatabase& database, const SymbolGro
 		for (FunctionHandle handle : functions_with_same_address) {
 			ccc::Function* function = database.functions.symbol_from_handle(handle);
 			if (!function || !group.is_in_group(*function)
-				|| function->mangled_name() != test_function.mangled_name()) {
+				|| function->raw_name() != test_function.raw_name()) {
 				continue;
 			}
 
@@ -588,12 +588,12 @@ static void detect_fake_functions(
 
 		auto external_function = external_functions.find(function.address().value);
 		if (external_function == external_functions.end()
-			|| strcmp(function.mangled_name().c_str(), external_function->second->string) != 0) {
+			|| strcmp(function.raw_name().c_str(), external_function->second->string) != 0) {
 			database.functions.move_symbol(function.handle(), Address());
 
 			if (fake_function_count < 10) {
 				CCC_WARN("Discarding address of function symbol '%s' as it is probably incorrect.",
-					function.mangled_name().c_str());
+					function.raw_name().c_str());
 			} else if (fake_function_count == 10) {
 				CCC_WARN("Discarding more addresses of function symbols.");
 			}

--- a/src/ccc/symbol_database.cpp
+++ b/src/ccc/symbol_database.cpp
@@ -153,46 +153,22 @@ template <typename SymbolType>
 SymbolHandle<SymbolType> SymbolList<SymbolType>::first_handle_from_starting_address(Address address) const
 {
 	auto iterator = m_address_to_handle.find(address.value);
-	if (iterator != m_address_to_handle.end()) {
-		return iterator->second;
-	} else {
+	if (iterator == m_address_to_handle.end()) {
 		return SymbolHandle<SymbolType>();
 	}
-}
 
-template <typename SymbolType>
-std::vector<SymbolHandle<SymbolType>> SymbolList<SymbolType>::handles_from_name(const std::string& name) const
-{
-	std::vector<SymbolHandle<SymbolType>> handles;
-
-	auto [begin, end] = m_name_to_handle.equal_range(name);
-	for (auto iterator = begin; iterator != end; iterator++) {
-		handles.emplace_back(iterator->second);
-	}
-
-	return handles;
+	return iterator->second;
 }
 
 template <typename SymbolType>
 SymbolHandle<SymbolType> SymbolList<SymbolType>::first_handle_after_address(Address address) const
 {
 	auto iterator = m_address_to_handle.upper_bound(address.value);
-	if (iterator != m_address_to_handle.end()) {
-		return iterator->second;
-	} else {
+	if (iterator == m_address_to_handle.end()) {
 		return SymbolHandle<SymbolType>();
 	}
-}
 
-template <typename SymbolType>
-SymbolHandle<SymbolType> SymbolList<SymbolType>::first_handle_from_name(const std::string& name) const
-{
-	auto iterator = m_name_to_handle.find(name);
-	if (iterator != m_name_to_handle.end()) {
-		return iterator->second;
-	} else {
-		return SymbolHandle<SymbolType>();
-	}
+	return iterator->second;
 }
 
 template <typename SymbolType>
@@ -213,6 +189,55 @@ template <typename SymbolType>
 const SymbolType* SymbolList<SymbolType>::symbol_overlapping_address(Address address) const
 {
 	return const_cast<SymbolList<SymbolType>*>(this)->symbol_overlapping_address(address);
+}
+
+template <typename SymbolType>
+std::vector<SymbolHandle<SymbolType>> SymbolList<SymbolType>::handles_from_name(const std::string& name) const
+{
+	std::vector<SymbolHandle<SymbolType>> handles;
+
+	auto [begin, end] = m_name_to_handle.equal_range(name);
+	for (auto iterator = begin; iterator != end; iterator++) {
+		handles.emplace_back(iterator->second);
+	}
+
+	return handles;
+}
+
+template <typename SymbolType>
+SymbolHandle<SymbolType> SymbolList<SymbolType>::first_handle_from_name(const std::string& name) const
+{
+	auto iterator = m_name_to_handle.find(name);
+	if (iterator == m_name_to_handle.end()) {
+		return SymbolHandle<SymbolType>();
+	}
+
+	return iterator->second;
+}
+
+template <typename SymbolType>
+std::vector<SymbolHandle<SymbolType>> SymbolList<SymbolType>::handles_from_mangled_name(
+	const std::string& mangled_name) const
+{
+	std::vector<SymbolHandle<SymbolType>> handles;
+
+	auto [begin, end] = m_mangled_name_to_handle.equal_range(mangled_name);
+	for (auto iterator = begin; iterator != end; iterator++) {
+		handles.emplace_back(iterator->second);
+	}
+
+	return handles;
+}
+
+template <typename SymbolType>
+SymbolHandle<SymbolType> SymbolList<SymbolType>::first_handle_from_mangled_name(const std::string& mangled_name) const
+{
+	auto iterator = m_mangled_name_to_handle.find(mangled_name);
+	if (iterator == m_mangled_name_to_handle.end()) {
+		return SymbolHandle<SymbolType>();
+	}
+
+	return iterator->second;
 }
 
 template <typename SymbolType>
@@ -247,7 +272,6 @@ bool SymbolList<SymbolType>::empty() const
 {
 	return m_symbols.size() == 0;
 }
-
 
 template <typename SymbolType>
 s32 SymbolList<SymbolType>::size() const
@@ -307,7 +331,7 @@ Result<SymbolType*> SymbolList<SymbolType>::create_symbol(std::string name,
 	static const int DMGL_RET_POSTFIX = 1 << 5;
 
 	std::string demangled_name;
-	if constexpr (SymbolType::FLAGS & NAME_NEEDS_DEMANGLING) {
+	if constexpr (SymbolType::FLAGS & MANGLED_NAMES) {
 		if ((importer_flags & DONT_DEMANGLE_NAMES) == 0 && demangler.cplus_demangle) {
 			int demangler_flags = 0;
 			if (importer_flags & DEMANGLE_PARAMETERS)
@@ -327,10 +351,11 @@ Result<SymbolType*> SymbolList<SymbolType>::create_symbol(std::string name,
 	Result<SymbolType*> symbol = create_symbol(non_mangled_name, address, source, module_symbol);
 	CCC_RETURN_IF_ERROR(symbol);
 
-	if constexpr (SymbolType::FLAGS & NAME_NEEDS_DEMANGLING) {
+	if constexpr (SymbolType::FLAGS & MANGLED_NAMES) {
 		if (!demangled_name.empty()) {
-			(*symbol)->set_mangled_name(name);
+			(*symbol)->m_mangled_name = std::move(name);
 		}
+		link_mangled_name_map(**symbol);
 	}
 
 	return symbol;
@@ -371,18 +396,39 @@ bool SymbolList<SymbolType>::rename_symbol(SymbolHandle<SymbolType> handle, std:
 }
 
 template <typename SymbolType>
+bool SymbolList<SymbolType>::remangle_symbol(SymbolHandle<SymbolType> handle, std::string new_mangled_name)
+{
+	if constexpr (SymbolType::FLAGS & MANGLED_NAMES) {
+		SymbolType* symbol = symbol_from_handle(handle);
+		if (!symbol) {
+			return false;
+		}
+
+		if (symbol->mangled_name() != new_mangled_name) {
+			unlink_name_map(*symbol);
+			symbol->m_mangled_name = std::move(new_mangled_name);
+			link_name_map(*symbol);
+		}
+
+		return true;
+	}
+
+	return false;
+}
+
+template <typename SymbolType>
 void SymbolList<SymbolType>::merge_from(
 	SymbolList<SymbolType>& list, SymbolDatabase& src_database, SymbolDatabase& dest_database)
 {
-	m_address_to_handle.clear();
-	m_name_to_handle.clear();
-
 	std::vector<SymbolType> lhs = std::move(m_symbols);
 	std::vector<SymbolType> rhs = std::move(list.m_symbols);
 
-	m_symbols = std::vector<SymbolType>();
+	clear();
+	list.clear();
+
 	m_symbols.reserve(lhs.size() + rhs.size());
 
+	// Merge the lists such that the symbols are still sorted by their handles.
 	size_t lhs_pos = 0;
 	size_t rhs_pos = 0;
 	for (;;) {
@@ -406,13 +452,10 @@ void SymbolList<SymbolType>::merge_from(
 
 		link_address_map(*symbol);
 		link_name_map(*symbol);
+		link_mangled_name_map(*symbol);
 	}
 
 	CCC_ASSERT(m_symbols.size() == lhs.size() + rhs.size());
-
-	list.m_symbols.clear();
-	list.m_address_to_handle.clear();
-	list.m_name_to_handle.clear();
 }
 
 template <typename SymbolType>
@@ -468,6 +511,7 @@ void SymbolList<SymbolType>::destroy_marked_symbols()
 		if (symbol.m_marked_for_destruction) {
 			unlink_address_map(symbol);
 			unlink_name_map(symbol);
+			unlink_mangled_name_map(symbol);
 		} else {
 			remaining_symbols.emplace_back(std::move(symbol));
 		}
@@ -479,9 +523,10 @@ void SymbolList<SymbolType>::destroy_marked_symbols()
 template <typename SymbolType>
 void SymbolList<SymbolType>::clear()
 {
-	m_symbols.clear();
-	m_address_to_handle.clear();
-	m_name_to_handle.clear();
+	m_symbols = std::vector<SymbolType>();
+	m_address_to_handle = AddressToHandleMap();
+	m_name_to_handle = NameToHandleMap();
+	m_mangled_name_to_handle = NameToHandleMap();
 }
 
 template <typename SymbolType>
@@ -534,7 +579,9 @@ template <typename SymbolType>
 void SymbolList<SymbolType>::link_name_map(SymbolType& symbol)
 {
 	if constexpr (SymbolType::FLAGS & WITH_NAME_MAP) {
-		m_name_to_handle.emplace(symbol.name(), symbol.handle());
+		if (!symbol.name().empty()) {
+			m_name_to_handle.emplace(symbol.name(), symbol.handle());
+		}
 	}
 }
 
@@ -542,11 +589,39 @@ template <typename SymbolType>
 void SymbolList<SymbolType>::unlink_name_map(SymbolType& symbol)
 {
 	if constexpr (SymbolType::FLAGS & WITH_NAME_MAP) {
-		auto iterators = m_name_to_handle.equal_range(symbol.name());
-		for (auto iterator = iterators.first; iterator != iterators.second; iterator++) {
-			if (iterator->second == symbol.handle()) {
-				m_name_to_handle.erase(iterator);
-				break;
+		if (!symbol.name().empty()) {
+			auto iterators = m_name_to_handle.equal_range(symbol.name());
+			for (auto iterator = iterators.first; iterator != iterators.second; iterator++) {
+				if (iterator->second == symbol.handle()) {
+					m_name_to_handle.erase(iterator);
+					break;
+				}
+			}
+		}
+	}
+}
+
+template <typename SymbolType>
+void SymbolList<SymbolType>::link_mangled_name_map(SymbolType& symbol)
+{
+	if constexpr (SymbolType::FLAGS & MANGLED_NAMES) {
+		if (!symbol.mangled_name().empty()) {
+			m_mangled_name_to_handle.emplace(symbol.mangled_name(), symbol.handle());
+		}
+	}
+}
+
+template <typename SymbolType>
+void SymbolList<SymbolType>::unlink_mangled_name_map(SymbolType& symbol)
+{
+	if constexpr (SymbolType::FLAGS & MANGLED_NAMES) {
+		if (!symbol.mangled_name().empty()) {
+			auto iterators = m_mangled_name_to_handle.equal_range(symbol.mangled_name());
+			for (auto iterator = iterators.first; iterator != iterators.second; iterator++) {
+				if (iterator->second == symbol.handle()) {
+					m_mangled_name_to_handle.erase(iterator);
+					break;
+				}
 			}
 		}
 	}
@@ -655,16 +730,16 @@ void Function::set_local_variables(
 
 const std::string& Function::mangled_name() const
 {
+	return m_mangled_name;
+}
+
+const std::string& Function::raw_name() const
+{
 	if (!m_mangled_name.empty()) {
 		return m_mangled_name;
 	} else {
 		return name();
 	}
-}
-
-void Function::set_mangled_name(std::string mangled)
-{
-	m_mangled_name = std::move(mangled);
 }
 
 u32 Function::original_hash() const
@@ -710,16 +785,16 @@ void Function::on_destroy(SymbolDatabase* database)
 
 const std::string& GlobalVariable::mangled_name() const
 {
+	return m_mangled_name;
+}
+
+const std::string& GlobalVariable::raw_name() const
+{
 	if (!m_mangled_name.empty()) {
 		return m_mangled_name;
 	} else {
 		return name();
 	}
-}
-
-void GlobalVariable::set_mangled_name(std::string mangled)
-{
-	m_mangled_name = std::move(mangled);
 }
 
 // *****************************************************************************

--- a/src/ccc/symbol_database.h
+++ b/src/ccc/symbol_database.h
@@ -89,7 +89,7 @@ enum SymbolFlag
 	NO_SYMBOL_FLAGS = 0,
 	WITH_ADDRESS_MAP = 1 << 0,
 	WITH_NAME_MAP = 1 << 1,
-	NAME_NEEDS_DEMANGLING = 1 << 2
+	MANGLED_NAMES = 1 << 2
 };
 
 // A container class for symbols of a given type that maintains maps of their
@@ -125,14 +125,18 @@ public:
 	SymbolHandle<SymbolType> first_handle_from_starting_address(Address address) const;
 	SymbolHandle<SymbolType> first_handle_after_address(Address address) const;
 
-	// Lookup symbols by their name.
-	std::vector<SymbolHandle<SymbolType>> handles_from_name(const std::string& name) const;
-	SymbolHandle<SymbolType> first_handle_from_name(const std::string& name) const;
-
 	// Find a symbol with an address range that contains the provided address.
 	// For example, to find which function an instruction belongs to.
 	SymbolType* symbol_overlapping_address(Address address);
 	const SymbolType* symbol_overlapping_address(Address address) const;
+
+	// Lookup symbols by their name.
+	std::vector<SymbolHandle<SymbolType>> handles_from_name(const std::string& name) const;
+	SymbolHandle<SymbolType> first_handle_from_name(const std::string& name) const;
+
+	// Lookup functions and global variables by their mangled name.
+	std::vector<SymbolHandle<SymbolType>> handles_from_mangled_name(const std::string& mangled_name) const;
+	SymbolHandle<SymbolType> first_handle_from_mangled_name(const std::string& mangled_name) const;
 
 	// Convert handles to underlying array indices.
 	s32 index_from_handle(SymbolHandle<SymbolType> handle) const;
@@ -170,6 +174,10 @@ public:
 
 	// Update the name of a symbol without changing its handle.
 	bool rename_symbol(SymbolHandle<SymbolType> handle, std::string new_name);
+
+	// Update the mangled name of a function or global variable without changing
+	// its handle.
+	bool remangle_symbol(SymbolHandle<SymbolType> handle, std::string new_mangled_name);
 
 	// Move all the symbols from the passed src_list into this list.
 	void merge_from(SymbolList<SymbolType>& src_list, SymbolDatabase& src_database, SymbolDatabase& dest_database);
@@ -210,12 +218,17 @@ private:
 	void link_name_map(SymbolType& symbol);
 	void unlink_name_map(SymbolType& symbol);
 
+	// Keep the mangled name map in sync with the symbol list.
+	void link_mangled_name_map(SymbolType& symbol);
+	void unlink_mangled_name_map(SymbolType& symbol);
+
 	using AddressToHandleMap = std::multimap<u32, SymbolHandle<SymbolType>>;
 	using NameToHandleMap = std::multimap<std::string, SymbolHandle<SymbolType>>;
 
 	std::vector<SymbolType> m_symbols;
 	AddressToHandleMap m_address_to_handle;
 	NameToHandleMap m_name_to_handle;
+	NameToHandleMap m_mangled_name_to_handle;
 
 	// We share this between symbol lists of the same type so that we can merge
 	// them without having to rewrite all the handles.
@@ -371,7 +384,7 @@ class Function : public Symbol
 public:
 	static constexpr const SymbolDescriptor DESCRIPTOR = FUNCTION;
 	static constexpr const char* NAME = "Function";
-	static constexpr const u32 FLAGS = WITH_ADDRESS_MAP | WITH_NAME_MAP | NAME_NEEDS_DEMANGLING;
+	static constexpr const u32 FLAGS = WITH_ADDRESS_MAP | WITH_NAME_MAP | MANGLED_NAMES;
 
 	FunctionHandle handle() const { return m_handle; }
 	SourceFileHandle source_file() const { return m_source_file; }
@@ -383,8 +396,11 @@ public:
 	const std::optional<std::vector<LocalVariableHandle>>& local_variables() const;
 	void set_local_variables(std::optional<std::vector<LocalVariableHandle>> local_variables, SymbolDatabase& database);
 
+	// The mangled name of the symbol, or an empty string for unmangled symbols.
 	const std::string& mangled_name() const;
-	void set_mangled_name(std::string mangled);
+
+	// The raw name of the symbol, mangled or otherwise.
+	const std::string& raw_name() const;
 
 	// A hash of all the opcodes in the function, read from file.
 	u32 original_hash() const;
@@ -431,17 +447,21 @@ private:
 class GlobalVariable : public Symbol
 {
 	friend SourceFile;
+	friend SymbolList<GlobalVariable>;
 
 public:
 	static constexpr const SymbolDescriptor DESCRIPTOR = GLOBAL_VARIABLE;
 	static constexpr const char* NAME = "Global Variable";
-	static constexpr u32 FLAGS = WITH_ADDRESS_MAP | WITH_NAME_MAP | NAME_NEEDS_DEMANGLING;
+	static constexpr u32 FLAGS = WITH_ADDRESS_MAP | WITH_NAME_MAP | MANGLED_NAMES;
 
 	GlobalVariableHandle handle() const { return m_handle; }
 	SourceFileHandle source_file() const { return m_source_file; }
 
+	// The mangled name of the symbol, or an empty string for unmangled symbols.
 	const std::string& mangled_name() const;
-	void set_mangled_name(std::string mangled);
+
+	// The raw name of the symbol, mangled or otherwise.
+	const std::string& raw_name() const;
 
 	GlobalStorage storage;
 	StorageClass storage_class = STORAGE_CLASS_NONE;

--- a/test/ccc/symbol_database_tests.cpp
+++ b/test/ccc/symbol_database_tests.cpp
@@ -6,6 +6,9 @@
 #include "ccc/importer_flags.h"
 #include "ccc/symbol_database.h"
 
+#define HAVE_DECL_BASENAME 1
+#include "demangle.h"
+
 using namespace ccc;
 
 TEST(CCCSymbolDatabase, SymbolFromHandle)
@@ -142,17 +145,122 @@ TEST(CCCSymbolDatabase, HandlesFromName)
 
 	// Make sure we can look up A, B, and C by their names.
 	auto as = database.data_types.handles_from_name("A");
-	EXPECT_EQ(++as.begin(), as.end());
+	EXPECT_EQ(as.size(), 1);
 
 	auto bs = database.data_types.handles_from_name("B");
-	EXPECT_EQ(++(++bs.begin()), bs.end());
+	EXPECT_EQ(bs.size(), 2);
 
 	auto cs = database.data_types.handles_from_name("C");
-	EXPECT_EQ(++(++(++(cs.begin()))), cs.end());
+	EXPECT_EQ(cs.size(), 3);
 
 	// Make sure we can't look up D anymore.
 	auto ds = database.data_types.handles_from_name("D");
-	EXPECT_EQ(ds.begin(), ds.end());
+	EXPECT_EQ(ds.size(), 0);
+}
+
+TEST(CCCSymbolDatabase, HandlesFromMangledName)
+{
+	DemanglerFunctions demangler;
+	demangler.cplus_demangle = cplus_demangle;
+	demangler.cplus_demangle_opname = cplus_demangle_opname;
+
+	u32 flags = NO_IMPORTER_FLAGS;
+
+	SymbolDatabase database;
+
+	Result<SymbolSource*> source = database.symbol_sources.create_symbol("Source", SymbolSourceHandle());
+	CCC_GTEST_FAIL_IF_ERROR(source);
+
+	// Create the symbols.
+	Result<Function*> a = database.functions.create_symbol(
+		"A__Fi", (*source)->handle(), nullptr, Address(), flags, demangler);
+	CCC_GTEST_FAIL_IF_ERROR(a);
+
+	Result<Function*> b_1 = database.functions.create_symbol(
+		"B__Fi", (*source)->handle(), nullptr, Address(), flags, demangler);
+	CCC_GTEST_FAIL_IF_ERROR(b_1);
+
+	Result<Function*> b_2 = database.functions.create_symbol(
+		"B__Fi", (*source)->handle(), nullptr, Address(), flags, demangler);
+	CCC_GTEST_FAIL_IF_ERROR(b_2);
+
+	Result<Function*> c_1 = database.functions.create_symbol(
+		"C__Fi", (*source)->handle(), nullptr, Address(), flags, demangler);
+	CCC_GTEST_FAIL_IF_ERROR(c_1);
+
+	Result<Function*> c_2 = database.functions.create_symbol(
+		"C__Fi", (*source)->handle(), nullptr, Address(), flags, demangler);
+	CCC_GTEST_FAIL_IF_ERROR(c_2);
+
+	Result<Function*> c_3 = database.functions.create_symbol(
+		"C__Fi", (*source)->handle(), nullptr, Address(), flags, demangler);
+	CCC_GTEST_FAIL_IF_ERROR(c_3);
+
+	Result<Function*> d = database.functions.create_symbol(
+		"D__Fi", (*source)->handle(), nullptr, Address(), flags, demangler);
+	CCC_GTEST_FAIL_IF_ERROR(d);
+
+	// Destroy D.
+	database.functions.mark_symbol_for_destruction((*d)->handle(), &database);
+	database.destroy_marked_symbols();
+
+	// Make sure we can look up A, B, and C by their mangled names.
+	auto as = database.functions.handles_from_mangled_name("A__Fi");
+	EXPECT_EQ(as.size(), 1);
+
+	auto bs = database.functions.handles_from_mangled_name("B__Fi");
+	EXPECT_EQ(bs.size(), 2);
+
+	auto cs = database.functions.handles_from_mangled_name("C__Fi");
+	EXPECT_EQ(cs.size(), 3);
+
+	// Make sure we can't look up D anymore.
+	auto ds = database.functions.handles_from_mangled_name("D__Fi");
+	EXPECT_EQ(ds.size(), 0);
+}
+
+TEST(CCCSymbolDatabase, UnmangledSymbolsNotInMangledNameMap)
+{
+	DemanglerFunctions demangler;
+	demangler.cplus_demangle = cplus_demangle;
+	demangler.cplus_demangle_opname = cplus_demangle_opname;
+
+	u32 flags = NO_IMPORTER_FLAGS;
+
+	SymbolDatabase database;
+
+	Result<SymbolSource*> source = database.symbol_sources.create_symbol("Source", SymbolSourceHandle());
+	CCC_GTEST_FAIL_IF_ERROR(source);
+
+	Result<Function*> a = database.functions.create_symbol("A", (*source)->handle());
+	CCC_GTEST_FAIL_IF_ERROR(a);
+
+	Result<Function*> b = database.functions.create_symbol(
+		"B", (*source)->handle(), nullptr, Address(), flags, demangler);
+	CCC_GTEST_FAIL_IF_ERROR(b);
+
+	SymbolDatabase other_database;
+
+	Result<SymbolSource*> other_source = other_database.symbol_sources.create_symbol("Source", SymbolSourceHandle());
+	CCC_GTEST_FAIL_IF_ERROR(other_source);
+
+	Result<Function*> c = other_database.functions.create_symbol(
+		"C", (*other_source)->handle(), nullptr, Address(), flags, demangler);
+	CCC_GTEST_FAIL_IF_ERROR(c);
+
+	database.merge_from(other_database);
+
+	auto as = database.functions.handles_from_mangled_name("A");
+	EXPECT_EQ(as.size(), 0);
+
+	auto bs = database.functions.handles_from_mangled_name("B");
+	EXPECT_EQ(bs.size(), 0);
+
+	auto cs = database.functions.handles_from_mangled_name("C");
+	EXPECT_EQ(cs.size(), 0);
+
+	auto empty = database.functions.handles_from_mangled_name("");
+	EXPECT_EQ(empty.size(), 0);
 }
 
 static Result<FunctionHandle> create_function(


### PR DESCRIPTION
So we can eventually remove a hack from PCSX2's debugger.